### PR TITLE
Detect vertical video and don't crop

### DIFF
--- a/Backend/video.py
+++ b/Backend/video.py
@@ -153,9 +153,10 @@ def combine_videos(video_paths: List[str], max_duration: int) -> str:
 
         # Not all videos are same size,
         # so we need to resize them
-        clip = crop(clip, width=1080, height=1920, \
-                    x_center=clip.w / 2, \
-                    y_center=clip.h / 2)
+        if not clip.h > clip.w:
+            clip = crop(clip, width=1080, height=1920, \
+                        x_center=clip.w / 2, \
+                        y_center=clip.h / 2)
         clip = clip.resize((1080, 1920))
 
         clips.append(clip)


### PR DESCRIPTION
A simple "hotfix" to prevent the cropping of video that is already vertical. It only detects if height > width.

Thus it will distort videos with a different aspect ratio than 9:16
In practice vertical videos are almost always in this aspect ratio, so for the time being (until the cropping in general gets improved) this is a simple solution.