### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ images/*
 *.srt
 .history
 .DS_Store
+
+
+Backend/output*

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ images/*
 *.zip
 *.srt
 .history
+.DS_Store


### PR DESCRIPTION
ignores `.DS_Store` - This makes developing on MacOS much easier.

ignores temp files in the Backend folder