### PR TITLE
Save the found video with the largest resolution

### DIFF
--- a/Backend/search.py
+++ b/Backend/search.py
@@ -32,6 +32,7 @@ def search_for_stock_videos(query: str, api_key: str) -> List[str]:
     # Get first video url
     video_urls = []
     video_url = ""
+    video_res = 0
     try:
         video_urls = response["videos"][0]["video_files"]
     except Exception:
@@ -42,8 +43,10 @@ def search_for_stock_videos(query: str, api_key: str) -> List[str]:
     for video in video_urls:
         # Check if video has a download link
         if ".com/external" in video["link"]:
-            # Set video url
-            video_url = video["link"]
+            # Only save the URL with the largest resolution
+            if (video["width"]*video["height"]) > video_res:
+                video_url = video["link"]
+                video_res = video["width"]*video["height"]
 
     # Let user know
     print(colored(f"\t=>{video_url}", "cyan"))


### PR DESCRIPTION
Currently it iterates over all found urls of a video and overwrites the returned value until the last entry.  This results in potentially low quality video because the order of the urls in the json is seemingly random.

This change ensures only the url of the highest resolution version of a found video is saved and returned.