### PR TITLE
Fixing local subtitle generation (list -> typing.List)

### DIFF
--- a/Backend/video.py
+++ b/Backend/video.py
@@ -56,13 +56,13 @@ def __generate_subtitles_assemblyai(audio_path: str) -> str:
     return subtitles
 
 
-def __generate_subtitles_locally(sentences: list[str], audio_clips: list[AudioFileClip]) -> str:
+def __generate_subtitles_locally(sentences: List[str], audio_clips: List[AudioFileClip]) -> str:
     """
     Generates subtitles from a given audio file and returns the path to the subtitles.
 
     Args:
-        sentences (list[str]): all the sentences said out loud in the audio clips
-        audio_clips (list[AudioFileClip]): all the individual audio clips which will make up the final audio track
+        sentences (List[str]): all the sentences said out loud in the audio clips
+        audio_clips (List[AudioFileClip]): all the individual audio clips which will make up the final audio track
     Returns:
         str: The generated subtitles
     """
@@ -89,14 +89,14 @@ def __generate_subtitles_locally(sentences: list[str], audio_clips: list[AudioFi
     return "\n".join(subtitles)
 
 
-def generate_subtitles(audio_path: str, sentences: list[str], audio_clips: list[AudioFileClip]) -> str:
+def generate_subtitles(audio_path: str, sentences: List[str], audio_clips: List[AudioFileClip]) -> str:
     """
     Generates subtitles from a given audio file and returns the path to the subtitles.
 
     Args:
         audio_path (str): The path to the audio file to generate subtitles from.
-        sentences (list[str]): all the sentences said out loud in the audio clips
-        audio_clips (list[AudioFileClip]): all the individual audio clips which will make up the final audio track
+        sentences (List[str]): all the sentences said out loud in the audio clips
+        audio_clips (List[AudioFileClip]): all the individual audio clips which will make up the final audio track
 
     Returns:
         str: The path to the generated subtitles.
@@ -135,7 +135,7 @@ def combine_videos(video_paths: List[str], max_duration: int) -> str:
     Combines a list of videos into one video and returns the path to the combined video.
 
     Args:
-        video_paths (list): A list of paths to the videos to combine.
+        video_paths (List): A list of paths to the videos to combine.
         max_duration (int): The maximum duration of the combined video.
 
     Returns:


### PR DESCRIPTION
Fixing misspelled function call, list to List from "typing" lib on Backend/video.py.