### PR TITLE
Improve cropping

### DIFF
--- a/Backend/video.py
+++ b/Backend/video.py
@@ -156,8 +156,8 @@ def combine_videos(video_paths: List[str], max_duration: int) -> str:
 
         # Not all videos are same size,
         # so we need to resize them
-        if not clip.h > clip.w:
-            clip = crop(clip, width=1080, height=1920, \
+        if not round((clip.w/clip.h), 4) == 0.5625:
+            clip = crop(clip, width=round(0.5625*clip.h), height=clip.h, \
                         x_center=clip.w / 2, \
                         y_center=clip.h / 2)
         clip = clip.resize((1080, 1920))


### PR DESCRIPTION
Crops a vertical slide in 9:16 aspect ratio exactly in the height of the given video clip and only resizes it afterwards. This greatly improves quality as now it doesn't crop a strange zoomed in portion of the video.

Also I improved the detection of vertical video slightly.