### PR TITLE
Improve search, ensure 5 valid results

### DIFF
--- a/Backend/main.py
+++ b/Backend/main.py
@@ -73,7 +73,8 @@ def generate():
 
         # Search for a video of the given search term
         video_urls = []
-
+        #defines how many results it should query and search through
+        it = 10
         # Loop through all search terms,
         # and search for a video of the given search term
         for search_term in search_terms:
@@ -86,17 +87,19 @@ def generate():
                     }
                 )
             found_url = search_for_stock_videos(
-                search_term, os.getenv("PEXELS_API_KEY")
+                search_term, os.getenv("PEXELS_API_KEY"), it
             )
-
-            if found_url != None and found_url not in video_urls and found_url != "":
-                video_urls.append(found_url)
+            #check for duplicates
+            for url in found_url:
+                if url not in video_urls:
+                    video_urls.append(url)
+                    break
 
         # Define video_paths
         video_paths = []
 
         # Let user know
-        print(colored("[+] Downloading videos...", "blue"))
+        print(colored(f"[+] Downloading {len(video_urls)} videos...", "blue"))
 
         # Save the videos
         for video_url in video_urls:

--- a/Backend/search.py
+++ b/Backend/search.py
@@ -3,7 +3,7 @@ import requests
 from typing import List
 from termcolor import colored
 
-def search_for_stock_videos(query: str, api_key: str) -> List[str]:
+def search_for_stock_videos(query: str, api_key: str, it: int) -> List[str]:
     """
     Searches for stock videos based on a query.
 
@@ -21,35 +21,43 @@ def search_for_stock_videos(query: str, api_key: str) -> List[str]:
     }
 
     # Build URL
-    url = f"https://api.pexels.com/videos/search?query={query}&per_page=1"
+    qurl = f"https://api.pexels.com/videos/search?query={query}&per_page={it}"
 
     # Send the request
-    r = requests.get(url, headers=headers)
+    r = requests.get(qurl, headers=headers)
 
     # Parse the response
     response = r.json()
 
-    # Get first video url
-    video_urls = []
-    video_url = ""
+    # Parse each video
+    raw_urls = []
+    video_url = []
     video_res = 0
     try:
-        video_urls = response["videos"][0]["video_files"]
-    except Exception:
+        # loop through each video in the result
+        for i in range(it):
+            raw_urls = response["videos"][i]["video_files"]
+            temp_video_url = ""
+            
+            # loop through each url to determine the best quality
+            for video in raw_urls:
+                # Check if video has a valid download link
+                if ".com/external" in video["link"]:
+                    # Only save the URL with the largest resolution
+                    if (video["width"]*video["height"]) > video_res:
+                        temp_video_url = video["link"]
+                        video_res = video["width"]*video["height"]
+                        
+            # add the url to the return list if it's not empty
+            if temp_video_url != "":
+                video_url.append(temp_video_url)
+                
+    except Exception as e:
         print(colored("[-] No Videos found.", "red"))
-        print(colored(response, "red"))
-
-    # Loop through video urls
-    for video in video_urls:
-        # Check if video has a download link
-        if ".com/external" in video["link"]:
-            # Only save the URL with the largest resolution
-            if (video["width"]*video["height"]) > video_res:
-                video_url = video["link"]
-                video_res = video["width"]*video["height"]
+        print(colored(e, "red"))
 
     # Let user know
-    print(colored(f"\t=>{video_url}", "cyan"))
+    print(colored(f"\t=> \"{query}\" found {len(video_url)} Videos", "cyan"))
 
     # Return the video url
     return video_url


### PR DESCRIPTION
This fixes two bugs associated with searching and downloading videos which causes fewer than 5 to be downloaded.

1) Sometimes Pexels API returns an url with ".com/progressive_redirect/", which I'm not sure if it can download it or not. ( I had mixed results). Currently it only accepts urls with ".com/external", thus it can happen that a search term returns an empty url.

2) Sometimes duplicate urls are returned for different search terms. Currently there is a check in place that rejects duplicates but it results in fewer than 5 videos. 

This change does following:  

search.py:
Request multiple results for each search term instead of one.
Iterate through all results and check if the urls match the requirement ".com/external" - it returns a list of all positive results.

main.py:
Iterate through the returned list of urls for each search term and generate a list of urls that is to be downloaded. 
If a duplicate is found it will use the next valid search result. 

Notes:
If urls with ".com/progressive_redirect/" can consistenly be downloaded, the if statement in search.py can be adjusted accordingly. This ensure fewer videos get rejected.
