### PR TITLE
Fix search term parsing

### DIFF
--- a/Backend/gpt.py
+++ b/Backend/gpt.py
@@ -115,9 +115,6 @@ def get_search_terms(video_subject: str, amount: int, script: str) -> List[str]:
         if not search_terms:
             print(colored("[-] Could not parse response.", "red"))
 
-        # Load the array into a JSON-Array
-        search_terms = json.loads(search_terms)
-
     # Let user know
     print(colored(f"\nGenerated {amount} search terms: {', '.join(search_terms)}", "cyan"))
 


### PR DESCRIPTION
Potentially fixes #70 

When Chatgpt returns an invalid json it tries to fix it but makes the mistake of trying to json.loads a string list afterwards.
It is not necessary to Json-ify that list.

PLEASE TEST. Since this error is random and there is no way to provoke a false reply from ChatGPT this needs further testing.
In my tests it worked.