### PR TITLE
Sync video duration to audio duration

### DIFF
--- a/Backend/main.py
+++ b/Backend/main.py
@@ -78,8 +78,10 @@ def generate():
 
         # Search for a video of the given search term
         video_urls = []
-        #defines how many results it should query and search through
-        it = 10
+        # defines how many results it should query and search through
+        it = 15
+        # defines the minimum duration of each clip
+        min_dur = 10
         # Loop through all search terms,
         # and search for a video of the given search term
         for search_term in search_terms:
@@ -92,7 +94,7 @@ def generate():
                     }
                 )
             found_url = search_for_stock_videos(
-                search_term, os.getenv("PEXELS_API_KEY"), it
+                search_term, os.getenv("PEXELS_API_KEY"), it, min_dur
             )
             #check for duplicates
             for url in found_url:

--- a/Backend/search.py
+++ b/Backend/search.py
@@ -3,7 +3,7 @@ import requests
 from typing import List
 from termcolor import colored
 
-def search_for_stock_videos(query: str, api_key: str, it: int) -> List[str]:
+def search_for_stock_videos(query: str, api_key: str, it: int, min_dur: int) -> List[str]:
     """
     Searches for stock videos based on a query.
 
@@ -36,6 +36,9 @@ def search_for_stock_videos(query: str, api_key: str, it: int) -> List[str]:
     try:
         # loop through each video in the result
         for i in range(it):
+            #check if video has desired minimum duration
+            if response["videos"][i]["duration"] < min_dur:
+                continue
             raw_urls = response["videos"][i]["video_files"]
             temp_video_url = ""
             

--- a/Backend/video.py
+++ b/Backend/video.py
@@ -143,30 +143,44 @@ def combine_videos(video_paths: List[str], max_duration: int) -> str:
     """
     video_id = uuid.uuid4()
     combined_video_path = f"../temp/{video_id}.mp4"
+    
+    #required duration of each clip:
+    req_dur = max_duration / len(video_paths)
 
     print(colored("[+] Combining videos...", "blue"))
-    print(colored(f"[+] Each video will be {max_duration / len(video_paths)} seconds long.", "blue"))
+    print(colored(f"[+] Each clip will be maximum {req_dur} seconds long.", "blue"))
 
     clips = []
-    for video_path in video_paths:
-        clip = VideoFileClip(video_path)
-        clip = clip.without_audio()
-        clip = clip.subclip(0, max_duration / len(video_paths))
-        clip = clip.set_fps(30)
+    tot_dur = 0
+    #add downloaded clips over and over until the duration of the audio (max_duration) has been reached
+    while tot_dur < max_duration:
+        for video_path in video_paths:
+            clip = VideoFileClip(video_path)
+            clip = clip.without_audio()
+            # check if clip is longer than the remaning audio
+            if (max_duration - tot_dur) < clip.duration:
+                clip = clip.subclip(0, (max_duration - tot_dur))
+            # only shorten clips if the calculated clip length (req_dur) is shorter than the actual clip to prevent still image
+            elif req_dur < clip.duration:
+                clip = clip.subclip(0, req_dur)
+            clip = clip.set_fps(30)
 
-        # Not all videos are same size,
-        # so we need to resize them
-        if round((clip.w/clip.h), 4) < 0.5625:
-            clip = crop(clip, width=clip.w, height=round(clip.w/0.5625), \
-                        x_center=clip.w / 2, \
-                        y_center=clip.h / 2)
-        else:
-            clip = crop(clip, width=round(0.5625*clip.h), height=clip.h, \
-                        x_center=clip.w / 2, \
-                        y_center=clip.h / 2)
-        clip = clip.resize((1080, 1920))
+            # Not all videos are same size,
+            # so we need to resize them
+            if round((clip.w/clip.h), 4) < 0.5625:
+                clip = crop(clip, width=clip.w, height=round(clip.w/0.5625), \
+                            x_center=clip.w / 2, \
+                            y_center=clip.h / 2)
+            else:
+                clip = crop(clip, width=round(0.5625*clip.h), height=clip.h, \
+                            x_center=clip.w / 2, \
+                            y_center=clip.h / 2)
+            clip = clip.resize((1080, 1920))
 
-        clips.append(clip)
+            clips.append(clip)
+            tot_dur += clip.duration
+            if tot_dur >= max_duration:
+                break
 
     final_clip = concatenate_videoclips(clips)
     final_clip = final_clip.set_fps(30)


### PR DESCRIPTION
This fixes #42 

I implemented a failsafe to ensure there is always enough video for the audio. No more still images or black images. 

Following was changed:

search.py, main.py:
There is now a minimum duration for clips. (Default 10 seconds). Only longer clips will be accepted and downloaded.
This will reduce potential videos further but no worries because there is a failsafe and I increased the search results from 10 to 15.

video.py (combine_videos): The Failsafe
During clip combining it now calculates the remaning video length required to so that video and audio are the same length.
It will continue to add clips from the same downloaded ones until the video length matches the audio length.
Of course it will also check if a clip is too long and only add as much as needed to fill the audio length. It is perfectly matched.

Notes:
One downside that remains with this is that for long videos clips may be repeated BUT the ultimate goal is to have < 60 second videos anyway and with a minimum length of 10 seconds per clip and 5 clips (or increase to 6), it will never repeat. Thus this change will become only a failsafe.

Tested & works for me.