### PR TITLE
Abort video download process if no videos are found

### DIFF
--- a/Backend/main.py
+++ b/Backend/main.py
@@ -102,6 +102,17 @@ def generate():
                     video_urls.append(url)
                     break
 
+        # Check if video_urls is empty
+        if not video_urls:
+            print(colored("[-] No videos found to download.", "red"))
+            return jsonify(
+                {
+                    "status": "error",
+                    "message": "No videos found to download.",
+                    "data": [],
+                }
+            )
+            
         # Define video_paths
         video_paths = []
 


### PR DESCRIPTION
This pull request introduces a check for an empty `video_urls` list before the video downloading process begins. If no videos are found, the process is aborted with an appropriate error message, following the existing error handling pattern. 

This prevents unnecessary attempts to download when there are no videos and provides clear feedback to the user.

Changes:
- Added a check for an empty `video_urls` list in /Backend/main.py before downloading.
- If the list is empty, the process is aborted with a JSON response indicating the error.