### PR TITLE
Remove hidden class from generate button on successful completion

### DIFF
--- a/Frontend/index.html
+++ b/Frontend/index.html
@@ -188,6 +188,7 @@
             alert(data.message);
             // Hide cancel button after generation is complete
             generateButton.disabled = false;
+            generateButton.classList.remove("hidden");
             cancelButton.classList.add("hidden");
           })
           .catch((error) => {


### PR DESCRIPTION
This pull request removes the hidden class on the generate button once complete.

@FujiwaraChoki  Note: this could be done as a contained 'resetUI' function where the form inputs are cleared as well, but that is outside the scope of this commit or pull request