### PR TITLE
Refactor docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,9 @@
-FROM ubuntu:22.04
+FROM python:3.11-slim-buster
 
-RUN apt-get update && apt-get install --no-install-recommends -y python3.11 \
-    python3-dev python3-pip build-essential \
-    autoconf pkg-config wget ghostscript
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    build-essential autoconf pkg-config wget ghostscript curl libpng-dev
 
-RUN apt-get update && apt-get install -y wget && \
-    apt-get install -y build-essential curl libpng-dev && \
-    wget https://github.com/ImageMagick/ImageMagick/archive/refs/tags/7.1.0-31.tar.gz && \
+RUN wget https://github.com/ImageMagick/ImageMagick/archive/refs/tags/7.1.0-31.tar.gz && \
     tar xzf 7.1.0-31.tar.gz && \
     rm 7.1.0-31.tar.gz && \
     apt-get clean && \
@@ -17,14 +14,10 @@ RUN sh ./ImageMagick-7.1.0-31/configure --prefix=/usr/local --with-bzlib=yes --w
 
 WORKDIR /tmp
 
-
 RUN pip install --upgrade pip
 
 WORKDIR /app
 
 ADD ./requirements.txt .
-RUN pip install -r requirements.txt
 
-ADD ./Backend ./backend
-ADD ./Frontend ./frontend
-ADD ./fonts ./fonts
+RUN pip install -r requirements.txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     ports:
       - "8001:8001"
     command: ["python3", "-m", "http.server", "8001", "--directory", "frontend"]
+    volumes:
+      - ./Frontend:/app/frontend
     restart: always
   backend:
     build:
@@ -19,11 +21,14 @@ services:
     command: ["python3", "backend/main.py"]
     volumes:
       - ./files:/temp
+      - ./Backend:/app/backend
+      - ./fonts:/app/fonts
     environment:
-      - ASSEMBLY_AI_API_KEY=
-      - TIKTOK_SESSION_ID=
+      - ASSEMBLY_AI_API_KEY=${ASSEMBLY_AI_API_KEY}
+      - TIKTOK_SESSION_ID=${TIKTOK_SESSION_ID}
       - IMAGEMAGICK_BINARY=/usr/local/bin/magick
-      - PEXELS_API_KEY=
+      - PEXELS_API_KEY=${PEXELS_API_KEY}
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
     depends_on:
       - frontend
     restart: always


### PR DESCRIPTION
Refactors docker setup to:
- use values defined in the `.env` file
- mounts the `Backend` and `Frontend` folders, so that you can work on the code without having to rebuild the images
- changes the image to one that requires less space
- cleans up the docker file itself

Now only a change in the `requirements.txt` requires a rebuild