### PR TITLE
Refactored Frontend and split js into separat file

### DIFF
--- a/Frontend/app.js
+++ b/Frontend/app.js
@@ -1,0 +1,116 @@
+const videoSubject = document.querySelector("#videoSubject");
+const aiModel = document.querySelector("#aiModel");
+const voice = document.querySelector("#voice");
+const zipUrl = document.querySelector("#zipUrl");
+const paragraphNumber = document.querySelector("#paragraphNumber");
+const youtubeToggle = document.querySelector("#youtubeUploadToggle");
+const useMusicToggle = document.querySelector("#useMusicToggle");
+const generateButton = document.querySelector("#generateButton");
+const cancelButton = document.querySelector("#cancelButton");
+
+const cancelGeneration = () => {
+  console.log("Canceling generation...");
+  // Send request to /cancel
+  fetch("http://localhost:8080/api/cancel", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+  })
+    .then((response) => response.json())
+    .then((data) => {
+      alert(data.message);
+      console.log(data);
+    })
+    .catch((error) => {
+      alert("An error occurred. Please try again later.");
+      console.log(error);
+    });
+
+  // Hide cancel button
+  cancelButton.classList.add("hidden");
+
+  // Enable generate button
+  generateButton.disabled = false;
+  generateButton.classList.remove("hidden");
+};
+
+const generateVideo = () => {
+  console.log("Generating video...");
+  // Disable button and change text
+  generateButton.disabled = true;
+  generateButton.classList.add("hidden");
+
+  // Show cancel button
+  cancelButton.classList.remove("hidden");
+
+  // Get values from input fields
+  const videoSubjectValue = videoSubject.value;
+  const aiModelValue = aiModel.value;
+  const voiceValue = voice.value;
+  const paragraphNumberValue = paragraphNumber.value;
+  const youtubeUpload = youtubeToggle.checked;
+  const useMusicToggleState = useMusicToggle.checked;
+  const zipUrlValue = zipUrl.value;
+
+  const url = "http://localhost:8080/api/generate";
+
+  // Construct data to be sent to the server
+  const data = {
+    videoSubject: videoSubjectValue,
+    aiModel: aiModelValue,
+    voice: voiceValue,
+    paragraphNumber: paragraphNumberValue,
+    automateYoutubeUpload: youtubeUpload,
+    useMusic: useMusicToggleState,
+    zipUrl: zipUrlValue,
+  };
+
+  // Send the actual request to the server
+  fetch(url, {
+    method: "POST",
+    body: JSON.stringify(data),
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+  })
+    .then((response) => response.json())
+    .then((data) => {
+      console.log(data);
+      alert(data.message);
+      // Hide cancel button after generation is complete
+      generateButton.disabled = false;
+      generateButton.classList.remove("hidden");
+      cancelButton.classList.add("hidden");
+    })
+    .catch((error) => {
+      alert("An error occurred. Please try again later.");
+      console.log(error);
+    });
+};
+
+generateButton.addEventListener("click", generateVideo);
+cancelButton.addEventListener("click", cancelGeneration);
+
+videoSubject.addEventListener("keyup", (event) => {
+  if (event.key === "Enter") {
+    generateVideo();
+  }
+});
+
+// Load the data from localStorage on page load
+document.addEventListener("DOMContentLoaded", (event) => {
+  const voiceSelect = document.getElementById("voice");
+  const storedVoiceValue = localStorage.getItem("voiceValue");
+
+  if (storedVoiceValue) {
+    voiceSelect.value = storedVoiceValue;
+  }
+});
+
+// When the voice select field changes, store the new value in localStorage.
+document.getElementById("voice").addEventListener("change", (event) => {
+  localStorage.setItem("voiceValue", event.target.value);
+});

--- a/Frontend/index.html
+++ b/Frontend/index.html
@@ -13,272 +13,174 @@
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.0.2/tailwind.min.css"
     />
+    <script src="app.js" defer></script>
   </head>
 
-  <body class="bg-blue-100 min-h-screen justify-center p-40">
-    <h1 class="text-4xl text-center mb-4">MoneyPrinter</h1>
-    <p class="text-center text-gray-700">
-      This Application is intended to automate the creation and uploads of
-      YouTube Shorts.
-    </p>
-
-    <div class="flex justify-center mt-8">
-      <div class="max-w-xl flex flex-col space-y-4 w-full">
-        <label for="aiModel" class="text-blue-600">AI Model</label>
-        <select
-          name="aiModel"
-          id="aiModel"
-          class="w-full border-2 border-blue-300 p-2 rounded-md focus:outline-none focus:border-blue-500"
-        >
-          <option value="g4f">g4f (Free)</option>
-          <option value="gpt3.5-turbo">OpenAI GPT-3.5</option>
-          <option value="gpt4">OpenAI GPT-4</option>
-        </select>
-        <label for="voice" class="text-blue-600">Voice</label>
-        <select
-          name="voice"
-          id="voice"
-          class="w-min border-2 border-blue-300 p-2 rounded-md focus:outline-none focus:border-blue-500"
-        >
-          <option value="en_us_ghostface">Ghost Face</option>
-          <option value="en_us_chewbacca">Chewbacca</option>
-          <option value="en_us_c3po">C3PO</option>
-          <option value="en_us_stitch">Stitch</option>
-          <option value="en_us_stormtrooper">Stormtrooper</option>
-          <option value="en_us_rocket">Rocket</option>
-          <option value="en_au_001">English AU - Female</option>
-          <option value="en_au_002">English AU - Male</option>
-          <option value="en_uk_001">English UK - Male 1</option>
-          <option value="en_uk_003">English UK - Male 2</option>
-          <option value="en_us_001">English US - Female (Int. 1)</option>
-          <option value="en_us_002">English US - Female (Int. 2)</option>
-          <option value="en_us_006">English US - Male 1</option>
-          <option value="en_us_007">English US - Male 2</option>
-          <option value="en_us_009">English US - Male 3</option>
-          <option value="en_us_010">English US - Male 4</option>
-          <option value="fr_001">French - Male 1</option>
-          <option value="fr_002">French - Male 2</option>
-          <option value="de_001">German - Female</option>
-          <option value="de_002">German - Male</option>
-          <option value="es_002">Spanish - Male</option>
-          <option value="es_mx_002">Spanish MX - Male</option>
-          <option value="br_001">Portuguese BR - Female 1</option>
-          <option value="br_003">Portuguese BR - Female 2</option>
-          <option value="br_004">Portuguese BR - Female 3</option>
-          <option value="br_005">Portuguese BR - Male</option>
-          <option value="id_001">Indonesian - Female</option>
-          <option value="jp_001">Japanese - Female 1</option>
-          <option value="jp_003">Japanese - Female 2</option>
-          <option value="jp_005">Japanese - Female 3</option>
-          <option value="jp_006">Japanese - Male</option>
-          <option value="kr_002">Korean - Male 1</option>
-          <option value="kr_003">Korean - Female</option>
-          <option value="kr_004">Korean - Male 2</option>
-          <option value="en_female_f08_salut_damour">Alto</option>
-          <option value="en_male_m03_lobby">Tenor</option>
-          <option value="en_female_f08_warmy_breeze">Warmy Breeze</option>
-          <option value="en_male_m03_sunshine_soon">Sunshine Soon</option>
-          <option value="en_male_narration">narrator</option>
-          <option value="en_male_funny">wacky</option>
-          <option value="en_female_emotional">peaceful</option>
-        </select>
-        <label for="zipUrl" class="text-blue-600"
-          >Zip URL (Leave empty for default)</label
-        >
-        <input
-          type="text"
-          name="zipUrl"
-          id="zipUrl"
-          class="border-2 border-blue-300 p-2 rounded-md focus:outline-none focus:border-blue-500"
-        />
-        <label for="videoSubject" class="text-blue-600">Subject</label>
-        <textarea
-          rows="3"
-          type="text"
-          name="videoSubject"
-          id="videoSubject"
-          class="border-2 border-blue-300 p-2 rounded-md focus:outline-none focus:border-blue-500"
-        ></textarea>
-        <label for="paragraphNumber" class="text-blue-600"
-          >Paragraph Number</label
-        >
-        <input
-          type="number"
-          name="paragraphNumber"
-          id="paragraphNumber"
-          class="border-2 border-blue-300 p-2 rounded-md focus:outline-none focus:border-blue-500"
-          value="1"
-          min="1"
-          max="100"
-        />
-        <label
-          for="youtubeUploadToggle"
-          class="flex items-center text-blue-600"
-        >
-          <input
-            type="checkbox"
-            name="youtubeUploadToggle"
-            id="youtubeUploadToggle"
-            class="mr-2"
-          />
-          Automate YouTube Uploads
-        </label>
-        <label for="useMusicToggle" class="flex items-center text-blue-600">
-          <input
-            type="checkbox"
-            name="useMusicToggle"
-            id="useMusicToggle"
-            class="mr-2"
-          />
-          Use Music
-        </label>
-        <button
-          id="generateButton"
-          class="bg-blue-500 hover:bg-blue-700 duration-100 linear text-white px-4 py-2 rounded-md"
-        >
-          Generate
-        </button>
-        <button
-          id="cancelButton"
-          class="bg-red-500 hover:bg-red-700 duration-100 linear text-white px-4 py-2 rounded-md hidden"
-        >
-          Cancel
-        </button>
-      </div>
-    </div>
-
-    <footer class="flex justify-center mt-8">
-      <div class="flex flex-col space-y-4">
+  <body class="bg-blue-100 min-h-screen flex flex-col justify-center">
+    <div>
+        <h1 class="text-4xl text-center mb-4">MoneyPrinter</h1>
         <p class="text-center text-gray-700">
-          Made with ❤️ by
-          <a
-            class="text-blue-600"
-            target="href"
-            href="https://github.com/FujiwaraChoki"
-          >
-            Fuji Codes
-          </a>
+          This Application is intended to automate the creation and uploads of
+          YouTube Shorts.
         </p>
-      </div>
-    </footer>
+    
+        <div class="flex justify-center mt-8">
+          <div class="max-w-xl flex flex-col space-y-4 w-full">
+            <div class="flex justify-between space-x-4">
+                <div class="w-min">
+                    <label for="aiModel" class="text-blue-600">AI Model</label>
+                    <select
+                      name="aiModel"
+                      id="aiModel"
+                      class="border-2 border-blue-300 p-2 rounded-md focus:outline-none focus:border-blue-500 w-40"
+                    >
+                      <option value="g4f">g4f (Free)</option>
+                      <option value="gpt3.5-turbo">OpenAI GPT-3.5</option>
+                      <option value="gpt4">OpenAI GPT-4</option>
+                    </select>
+                </div>
+                <div>
+                    <label for="voice" class="text-blue-600">Voice</label>
+                    <select
+                      name="voice"
+                      id="voice"
+                      class="w-full border-2 border-blue-300 p-2 rounded-md focus:outline-none focus:border-blue-500"
+                    >
+                      <option value="en_us_ghostface">Ghost Face</option>
+                      <option value="en_us_chewbacca">Chewbacca</option>
+                      <option value="en_us_c3po">C3PO</option>
+                      <option value="en_us_stitch">Stitch</option>
+                      <option value="en_us_stormtrooper">Stormtrooper</option>
+                      <option value="en_us_rocket">Rocket</option>
+                      <option value="en_au_001">English AU - Female</option>
+                      <option value="en_au_002">English AU - Male</option>
+                      <option value="en_uk_001">English UK - Male 1</option>
+                      <option value="en_uk_003">English UK - Male 2</option>
+                      <option value="en_us_001">English US - Female (Int. 1)</option>
+                      <option value="en_us_002">English US - Female (Int. 2)</option>
+                      <option value="en_us_006">English US - Male 1</option>
+                      <option value="en_us_007">English US - Male 2</option>
+                      <option value="en_us_009">English US - Male 3</option>
+                      <option value="en_us_010">English US - Male 4</option>
+                      <option value="fr_001">French - Male 1</option>
+                      <option value="fr_002">French - Male 2</option>
+                      <option value="de_001">German - Female</option>
+                      <option value="de_002">German - Male</option>
+                      <option value="es_002">Spanish - Male</option>
+                      <option value="es_mx_002">Spanish MX - Male</option>
+                      <option value="br_001">Portuguese BR - Female 1</option>
+                      <option value="br_003">Portuguese BR - Female 2</option>
+                      <option value="br_004">Portuguese BR - Female 3</option>
+                      <option value="br_005">Portuguese BR - Male</option>
+                      <option value="id_001">Indonesian - Female</option>
+                      <option value="jp_001">Japanese - Female 1</option>
+                      <option value="jp_003">Japanese - Female 2</option>
+                      <option value="jp_005">Japanese - Female 3</option>
+                      <option value="jp_006">Japanese - Male</option>
+                      <option value="kr_002">Korean - Male 1</option>
+                      <option value="kr_003">Korean - Female</option>
+                      <option value="kr_004">Korean - Male 2</option>
+                      <option value="en_female_f08_salut_damour">Alto</option>
+                      <option value="en_male_m03_lobby">Tenor</option>
+                      <option value="en_female_f08_warmy_breeze">Warmy Breeze</option>
+                      <option value="en_male_m03_sunshine_soon">Sunshine Soon</option>
+                      <option value="en_male_narration">narrator</option>
+                      <option value="en_male_funny">wacky</option>
+                      <option value="en_female_emotional">peaceful</option>
+                    </select>
+                </div>
+                <div class="w-min">
+                    <label for="paragraphNumber" class="text-blue-600"
+                    >Paragraph Number</label
+                  >
+                  <input
+                    type="number"
+                    name="paragraphNumber"
+                    id="paragraphNumber"
+                    class="border-2 border-blue-300 p-2 rounded-md focus:outline-none focus:border-blue-500 w-40"
+                    value="1"
+                    min="1"
+                    max="100"
+                  />
+                </div>
+            </div>
 
-    <script>
-      const videoSubject = document.querySelector("#videoSubject");
-      const aiModel = document.querySelector("#aiModel");
-      const voice = document.querySelector("#voice");
-      const zipUrl = document.querySelector("#zipUrl");
-      const paragraphNumber = document.querySelector("#paragraphNumber");
-      const youtubeToggle = document.querySelector("#youtubeUploadToggle");
-      const useMusicToggle = document.querySelector("#useMusicToggle");
-      const generateButton = document.querySelector("#generateButton");
-      const cancelButton = document.querySelector("#cancelButton");
+            <div class="w-full">
+                <label for="videoSubject" class="text-blue-600">Subject</label>
+                <textarea
+                  rows="3"
+                  type="text"
+                  name="videoSubject"
+                  id="videoSubject"
+                  class="border-2 border-blue-300 p-2 rounded-md focus:outline-none focus:border-blue-500 w-full"
+                ></textarea>
+            </div>
 
-      const cancelGeneration = () => {
-        console.log("Canceling generation...");
-        // Send request to /cancel
-        fetch("http://localhost:8080/api/cancel", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Accept: "application/json",
-          },
-        })
-          .then((response) => response.json())
-          .then((data) => {
-            alert(data.message);
-            console.log(data);
-          })
-          .catch((error) => {
-            alert("An error occurred. Please try again later.");
-            console.log(error);
-          });
+            <div class="flex space-x-4">
+                <label for="useMusicToggle" class="flex items-center text-blue-600 truncate">
+                    <input
+                        type="checkbox"
+                        name="useMusicToggle"
+                        id="useMusicToggle"
+                        class="mr-2 mt-1 w-4 h-4 rounded"
+                    />
+                    Use Music
+                </label>
+                <div class="flex-1">
+                    <label for="zipUrl" class="text-blue-600"
+                      >Zip URL For Music (Leave empty for default)</label
+                    >
+                    <input
+                      type="text"
+                      name="zipUrl"
+                      id="zipUrl"
+                      class="border-2 border-blue-300 p-2 rounded-md focus:outline-none focus:border-blue-500 w-full"
+                    />
+                </div>
+            </div>
 
-        // Hide cancel button
-        cancelButton.classList.add("hidden");
+            <label
+              for="youtubeUploadToggle"
+              class="flex items-center text-blue-600"
+            >
+              <input
+                type="checkbox"
+                name="youtubeUploadToggle"
+                id="youtubeUploadToggle"
+                class="mr-2 mt-1 w-4 h-4 rounded"
+              />
+              Automate YouTube Uploads
+            </label>
 
-        // Enable generate button
-        generateButton.disabled = false;
-        generateButton.classList.remove("hidden");
-      };
-
-      const generateVideo = () => {
-        console.log("Generating video...");
-        // Disable button and change text
-        generateButton.disabled = true;
-        generateButton.classList.add("hidden");
-
-        // Show cancel button
-        cancelButton.classList.remove("hidden");
-
-        // Get values from input fields
-        const videoSubjectValue = videoSubject.value;
-        const aiModelValue = aiModel.value;
-        const voiceValue = voice.value;
-        const paragraphNumberValue = paragraphNumber.value;
-        const youtubeUpload = youtubeToggle.checked;
-        const useMusicToggleState = useMusicToggle.checked;
-        const zipUrlValue = zipUrl.value;
-
-        const url = "http://localhost:8080/api/generate";
-
-        // Construct data to be sent to the server
-        const data = {
-          videoSubject: videoSubjectValue,
-          aiModel: aiModelValue,
-          voice: voiceValue,
-          paragraphNumber: paragraphNumberValue,
-          automateYoutubeUpload: youtubeUpload,
-          useMusic: useMusicToggleState,
-          zipUrl: zipUrlValue,
-        };
-
-        // Send the actual request to the server
-        fetch(url, {
-          method: "POST",
-          body: JSON.stringify(data),
-          headers: {
-            "Content-Type": "application/json",
-            Accept: "application/json",
-          },
-        })
-          .then((response) => response.json())
-          .then((data) => {
-            console.log(data);
-            alert(data.message);
-            // Hide cancel button after generation is complete
-            generateButton.disabled = false;
-            generateButton.classList.remove("hidden");
-            cancelButton.classList.add("hidden");
-          })
-          .catch((error) => {
-            alert("An error occurred. Please try again later.");
-            console.log(error);
-          });
-      };
-
-      generateButton.addEventListener("click", generateVideo);
-      cancelButton.addEventListener("click", cancelGeneration);
-
-      videoSubject.addEventListener("keyup", (event) => {
-        if (event.key === "Enter") {
-          generateVideo();
-        }
-      });
-
-      // Load the data from localStorage on page load
-      document.addEventListener("DOMContentLoaded", (event) => {
-        const voiceSelect = document.getElementById("voice");
-        const storedVoiceValue = localStorage.getItem("voiceValue");
-
-        if (storedVoiceValue) {
-          voiceSelect.value = storedVoiceValue;
-        }
-      });
-
-      // When the voice select field changes, store the new value in localStorage.
-      document.getElementById("voice").addEventListener("change", (event) => {
-        localStorage.setItem("voiceValue", event.target.value);
-      });
-    </script>
+            <button
+              id="generateButton"
+              class="bg-blue-500 hover:bg-blue-700 duration-100 linear text-white px-4 py-2 rounded-md"
+            >
+              Generate
+            </button>
+            <button
+              id="cancelButton"
+              class="bg-red-500 hover:bg-red-700 duration-100 linear text-white px-4 py-2 rounded-md hidden"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+    
+        <footer class="flex justify-center mt-8">
+          <div class="flex flex-col space-y-4">
+            <p class="text-center text-gray-700">
+              Made with ❤️ by
+              <a
+                class="text-blue-600"
+                target="href"
+                href="https://github.com/FujiwaraChoki"
+              >
+                Fuji Codes
+              </a>
+            </p>
+          </div>
+        </footer>
+    </div>
   </body>
 </html>


### PR DESCRIPTION
The frontend got quite crowded, so I refactored it to be more compact, this also removes the padding on top in favor of a flex box which centers everything vertically. In addition to that, I also extracted the JS code into a separate file `app.js` to make it easier to maintain (The App still runs flawlessly with `python -m http.server 3000`). I think this step is necessary in the long run, it does however conflict with all other PRs which also change something on the Frontend (Mainly https://github.com/FujiwaraChoki/MoneyPrinter/pull/130 and https://github.com/FujiwaraChoki/MoneyPrinter/pull/116)

![grafik](https://github.com/FujiwaraChoki/MoneyPrinter/assets/25080047/a7d6a0e2-96b0-41f4-9044-98b991329cc7)
