### PR TITLE
Return the generated script in voice language

### DIFF
--- a/Backend/gpt.py
+++ b/Backend/gpt.py
@@ -58,7 +58,7 @@ def generate_response(prompt: str, ai_model: str) -> str:
 
     return response
 
-def generate_script(video_subject: str, paragraph_number: int, ai_model: str) -> str:
+def generate_script(video_subject: str, paragraph_number: int, ai_model: str, voice: str) -> str:
 
     """
     Generate a script for a video, depending on the subject of the video, the number of paragraphs, and the AI model.
@@ -86,7 +86,7 @@ def generate_script(video_subject: str, paragraph_number: int, ai_model: str) ->
     Generate a script for a video, depending on the subject of the video.
     Subject: {video_subject}
     Number of paragraphs: {paragraph_number}
-
+    Language: {voice}
 
     The script is to be returned as a string with the specified number of paragraphs.
 
@@ -100,6 +100,7 @@ def generate_script(video_subject: str, paragraph_number: int, ai_model: str) ->
     Obviously, the script should be related to the subject of the video.
 
     YOU MUST NOT INCLUDE ANY TYPE OF MARKDOWN OR FORMATTING IN THE SCRIPT, NEVER USE A TITLE.
+    YOU MUST WRITE THE SCRIPT IN THE LANGUAGE SPECIFIED IN [LANGUAGE].
     ONLY RETURN THE RAW CONTENT OF THE SCRIPT. DO NOT INCLUDE "VOICEOVER", "NARRATOR" OR SIMILAR INDICATORS OF WHAT SHOULD BE SPOKEN AT THE BEGINNING OF EACH PARAGRAPH OR LINE. YOU MUST NOT MENTION THE PROMPT, OR ANYTHING ABOUT THE SCRIPT ITSELF. ALSO, NEVER TALK ABOUT THE AMOUNT OF PARAGRAPHS OR LINES. JUST WRITE THE SCRIPT.
     """
 

--- a/Backend/main.py
+++ b/Backend/main.py
@@ -84,14 +84,15 @@ def generate():
                     "data": [],
                 }
             )
-
-        # Generate a script
-        script = generate_script(data["videoSubject"], paragraph_number, ai_model)  # Pass the AI model to the script generation
+        
         voice = data["voice"]
 
         if not voice:
             print(colored("[!] No voice was selected. Defaulting to \"en_us_001\"", "yellow"))
             voice = "en_us_001"
+
+        # Generate a script
+        script = generate_script(data["videoSubject"], paragraph_number, ai_model, voice)  # Pass the AI model to the script generation
 
         # Generate search terms
         search_terms = get_search_terms(


### PR DESCRIPTION
Hello there!

I noticed something odd - even when I use the Brazilian Portuguese voice, the script stays in English. This pull request is to fix that, so the prompt matches the selected voice language, covering not only Portguese but also other available languages.

Thanks for the great tool!