### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,5 +16,5 @@ assemblyai
 brotli
 google-api-python-client 
 oauth2client
-openai==0.28
+openai
 google-generativeai


### PR DESCRIPTION
make openai undependable on version. 
openai 0.28 cause error [-] Error: module 'openai' has no attribute 'chat'