### PR TITLE
fix(openai): use latest version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,5 +16,5 @@ assemblyai
 brotli
 google-api-python-client 
 oauth2client
-openai
+openai==1.12.0
 google-generativeai


### PR DESCRIPTION
Update openai to the latest version to avoid "Error: module 'openai' has no attribute 'chat'"

This was probably introduced with this PR: https://github.com/FujiwaraChoki/MoneyPrinter/pull/155

For reference:
<img width="676" alt="Screenshot 2024-02-11 at 5 07 08 PM" src="https://github.com/FujiwaraChoki/MoneyPrinter/assets/2947763/6e112550-a207-4de7-b92a-5fa8e3c77fe4">
<img width="866" alt="Screenshot 2024-02-11 at 5 07 12 PM" src="https://github.com/FujiwaraChoki/MoneyPrinter/assets/2947763/5cdd375e-af76-4041-be0a-b2ed0d6d7dbd">
