### PR TITLE
feat: automatically open the video after creation

### DIFF
--- a/Frontend/app.js
+++ b/Frontend/app.js
@@ -5,6 +5,7 @@ const zipUrl = document.querySelector("#zipUrl");
 const paragraphNumber = document.querySelector("#paragraphNumber");
 const youtubeToggle = document.querySelector("#youtubeUploadToggle");
 const useMusicToggle = document.querySelector("#useMusicToggle");
+const openVideoAfterCreationToggle = document.querySelector("#openVideoAfterCreation");
 const customPrompt = document.querySelector("#customPrompt");
 const generateButton = document.querySelector("#generateButton");
 const cancelButton = document.querySelector("#cancelButton");
@@ -50,6 +51,10 @@ const cancelGeneration = () => {
   generateButton.classList.remove("hidden");
 };
 
+const openInNewTab = (url) => {
+  window.open(url, '_blank').focus();
+}
+
 const generateVideo = () => {
   console.log("Generating video...");
   // Disable button and change text
@@ -66,6 +71,7 @@ const generateVideo = () => {
   const paragraphNumberValue = paragraphNumber.value;
   const youtubeUpload = youtubeToggle.checked;
   const useMusicToggleState = useMusicToggle.checked;
+  const openVideoAfterCreationToggleState = openVideoAfterCreationToggle.checked;
   const threads = document.querySelector("#threads").value;
   const zipUrlValue = zipUrl.value;
   const customPromptValue = customPrompt.value;
@@ -81,6 +87,7 @@ const generateVideo = () => {
     paragraphNumber: paragraphNumberValue,
     automateYoutubeUpload: youtubeUpload,
     useMusic: useMusicToggleState,
+    openVideoAfterCreation: openVideoAfterCreationToggleState,
     zipUrl: zipUrlValue,
     threads: threads,
     subtitlesPosition: subtitlesPosition,
@@ -100,6 +107,9 @@ const generateVideo = () => {
     .then((data) => {
       console.log(data);
       alert(data.message);
+      if (data.link)  {
+        openInNewTab(data.link)
+      }
       // Hide cancel button after generation is complete
       generateButton.disabled = false;
       generateButton.classList.remove("hidden");

--- a/Frontend/index.html
+++ b/Frontend/index.html
@@ -176,6 +176,16 @@
             />
             Use Music
           </label>
+          <label for="openVideoAfterCreation" class="flex items-center text-blue-600">
+            <input
+              type="checkbox"
+              name="openVideoAfterCreation"
+              id="openVideoAfterCreation"
+              class="mr-2"
+              checked
+            />
+            Open Video After Creation
+          </label>
         </div>
         <button
           id="generateButton"

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If you need help, open [EnvironmentVariables.md](EnvironmentVariables.md) for mo
 1. Enter a topic to talk about
 1. Click on the "Generate" button
 1. Wait for the video to be generated
-1. The video's location is `MoneyPrinter/output.mp4`
+1. The video's location is `MoneyPrinter/Frontend/assets/output.mp4`
 
 ## Music 🎵
 


### PR DESCRIPTION
Automatically open the video to avoid the small friction of having to leave the UI to find it in the right folder.

It’s enabled by default:
<img width="707" alt="Screenshot 2024-02-12 at 3 44 27 PM" src="https://github.com/FujiwaraChoki/MoneyPrinter/assets/2947763/729247c4-a5d5-4329-aaec-ffafc38f46ce">
