### PR TITLE
Fix: Sanitize Video Title to Remove Extra Double Quotes During Upload

### DIFF
--- a/Backend/youtube.py
+++ b/Backend/youtube.py
@@ -173,7 +173,7 @@ def upload_video(video_path, title, description, category, keywords, privacy_sta
         # Initialize the upload process
         video_response = initialize_upload(youtube, {
             'file': video_path, # The path to the video file
-            'title': title,
+            'title': title.strip('"'),
             'description': description,
             'category': category, 
             'keywords': keywords,
@@ -187,7 +187,7 @@ def upload_video(video_path, title, description, category, keywords, privacy_sta
             youtube = get_authenticated_service() # This will prompt for re-authentication if necessary
             video_response = initialize_upload(youtube, {
                 'file': video_path,
-                'title': title,
+                'title': title.strip('"'),
                 'description': description,
                 'category': category,
                 'keywords': keywords,


### PR DESCRIPTION
This PR fixes an issue where video titles were being uploaded with extra double quotes. The title is now sanitized by stripping any leading or trailing double quotes before uploading the video to YouTube.

Changes include:
- A fix in the `upload_video` function to ensure the title is correctly formatted.
- Prevents the inclusion of unintended characters in video titles, improving the user experience.

This resolves potential issues with incorrectly formatted video titles on the platform.