### PR TITLE
feat: add DB-backed generation queue and worker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,4 +33,11 @@ OLLAMA_MODEL="llama3.1:8b"
 # Sign up at https://www.assemblyai.com/ to receive an API key.
 ASSEMBLY_AI_API_KEY=""
 
+# Database (PostgreSQL)
+# Docker default DSN points to the postgres service in docker-compose.
+POSTGRES_DB="moneyprinter"
+POSTGRES_USER="moneyprinter"
+POSTGRES_PASSWORD="moneyprinter"
+DATABASE_URL="postgresql+psycopg://moneyprinter:moneyprinter@localhost:5432/moneyprinter"
+
  

--- a/.env.example
+++ b/.env.example
@@ -33,11 +33,12 @@ OLLAMA_MODEL="llama3.1:8b"
 # Sign up at https://www.assemblyai.com/ to receive an API key.
 ASSEMBLY_AI_API_KEY=""
 
-# Database (PostgreSQL)
-# Docker default DSN points to the postgres service in docker-compose.
+# Database
+# Leave DATABASE_URL empty for local SQLite default.
+# In Docker Compose, empty DATABASE_URL uses postgres service fallback.
 POSTGRES_DB="moneyprinter"
 POSTGRES_USER="moneyprinter"
 POSTGRES_PASSWORD="moneyprinter"
-DATABASE_URL="postgresql+psycopg://moneyprinter:moneyprinter@localhost:5432/moneyprinter"
+DATABASE_URL=""
 
  

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ Follow it before making changes.
 
 ## 1) Repository Layout
 
-- `Backend/`: Flask API and video generation pipeline.
+- `Backend/`: Flask API, DB-backed job queue, and video generation pipeline.
 - `Frontend/`: static HTML/JS client served by `python -m http.server`.
 - `docs/`: source-of-truth setup and runtime docs.
 - `fonts/`, `Songs/`, `subtitles/`, `temp/`: runtime assets/output folders.
@@ -25,12 +25,13 @@ Follow it before making changes.
 - Create local env file: `cp .env.example .env`.
 - Install dependencies: `uv sync`.
 - Run backend: `uv run python Backend/main.py`.
+- Run worker (new terminal): `uv run python Backend/worker.py`.
 - Run frontend (new terminal): `python3 -m http.server 3000 --directory Frontend`.
 - Docker workflow: `docker compose up --build`.
 
 ## 4) Build, Lint, and Test Commands
 
-This project currently has no formal lint/test toolchain checked in (no `pytest`/`ruff` config present).
+This project has a baseline `pytest` setup for backend repository tests.
 Use the commands below as the expected agent workflow.
 
 ### 4.1 Build / Runtime Verification
@@ -38,7 +39,8 @@ Use the commands below as the expected agent workflow.
 - Backend syntax check: `uv run python -m compileall Backend`.
 - Frontend syntax sanity (lightweight): open `Frontend/index.html` in browser and run generation flow.
 - API smoke check after backend start: `curl http://localhost:8080/api/models`.
-- Full local run: backend + frontend servers, then generate a short sample video.
+- Queue smoke check: `curl -X POST http://localhost:8080/api/generate -H "Content-Type: application/json" -d '{"videoSubject":"test","voice":"en_us_001","paragraphNumber":1,"customPrompt":""}'`.
+- Full local run: backend + worker + frontend servers, then generate a short sample video.
 
 ### 4.2 Lint / Formatting (Recommended)
 
@@ -51,13 +53,11 @@ Use the commands below as the expected agent workflow.
 
 ### 4.3 Test Commands (Current and Future)
 
-- No committed test suite exists yet.
-- If tests are introduced with `pytest`, use:
-  - Run all tests: `uv run pytest -q`
-  - Run one file: `uv run pytest tests/test_file.py -q`
-  - Run a single test: `uv run pytest tests/test_file.py::test_name -q`
-  - Run a single class test: `uv run pytest tests/test_file.py::TestClass::test_name -q`
-- If tests live under `Backend/tests/`, keep the same selectors with that path.
+- Run all tests: `uv run pytest`
+- Run one file: `uv run pytest tests/test_file.py`
+- Run a single test: `uv run pytest tests/test_file.py::test_name`
+- Run a single class test: `uv run pytest tests/test_file.py::TestClass::test_name`
+- Current suite location: `tests/`.
 
 ## 5) High-Confidence Conventions from Existing Code
 
@@ -110,8 +110,8 @@ These conventions are inferred from current source and should guide new changes.
 
 - Keep endpoint payloads consistent with `{"status": "success|error", ...}`.
 - Use appropriate HTTP status codes for conflict/client errors (e.g., `409`, `400`).
-- Long-running work should remain off request thread (background thread pattern exists).
-- Preserve cancellation semantics using global generation state and SSE log streaming.
+- Long-running work should run in worker process from DB queue, not on request thread.
+- Preserve cancellation semantics using per-job cancellation and persisted job events.
 
 ### 5.8 Frontend Patterns
 
@@ -132,13 +132,14 @@ These conventions are inferred from current source and should guide new changes.
 
 - Ran relevant command(s) from section 4.
 - Confirmed backend still starts (`uv run python Backend/main.py`).
+- Confirmed worker still starts (`uv run python Backend/worker.py`).
 - Confirmed frontend still loads (`python3 -m http.server 3000 --directory Frontend`).
 - Verified changed endpoints still return JSON and preserve `status` field.
 - Checked no secrets were added to tracked files.
 
 ## 8) Notes for Future Tooling PRs
 
-- If adding tests, standardize on `pytest` and document exact paths/selectors here.
+- Keep tests standardized on `pytest` and document exact paths/selectors here.
 - If adding linting, prefer `ruff` for lint + format and commit config files.
 - If adding type checks, document command and strictness level (`mypy` or equivalent).
 - Keep this file updated whenever workflow commands change.

--- a/Backend/db.py
+++ b/Backend/db.py
@@ -15,7 +15,10 @@ class Base(DeclarativeBase):
 
 
 def _database_url() -> str:
-    return os.getenv("DATABASE_URL", "sqlite:///moneyprinter.db")
+    database_url = os.getenv("DATABASE_URL")
+    if database_url:
+        return database_url
+    return "sqlite:///moneyprinter.db"
 
 
 DATABASE_URL = _database_url()

--- a/Backend/db.py
+++ b/Backend/db.py
@@ -1,0 +1,39 @@
+import os
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import DeclarativeBase, sessionmaker
+
+from dotenv import load_dotenv
+from utils import ENV_FILE
+
+
+load_dotenv(ENV_FILE)
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+def _database_url() -> str:
+    return os.getenv("DATABASE_URL", "sqlite:///moneyprinter.db")
+
+
+DATABASE_URL = _database_url()
+
+engine = create_engine(
+    DATABASE_URL,
+    pool_pre_ping=True,
+    connect_args={"check_same_thread": False}
+    if DATABASE_URL.startswith("sqlite")
+    else {},
+)
+
+SessionLocal = sessionmaker(
+    bind=engine, autoflush=False, autocommit=False, expire_on_commit=False
+)
+
+
+def init_db() -> None:
+    from models import Artifact, GenerationEvent, GenerationJob, Project, Script  # noqa: F401
+
+    Base.metadata.create_all(bind=engine)

--- a/Backend/main.py
+++ b/Backend/main.py
@@ -3,7 +3,7 @@ import os
 from dotenv import load_dotenv
 from flask import Flask, jsonify, request
 from flask_cors import CORS
-from sqlalchemy import and_, select
+from sqlalchemy import and_, case, select
 
 from db import SessionLocal, init_db
 from gpt import list_ollama_models
@@ -163,7 +163,10 @@ def cancel_latest_running_job():
         stmt = (
             select(GenerationJob)
             .where(and_(GenerationJob.status.in_(["queued", "running"])))
-            .order_by(GenerationJob.created_at.desc())
+            .order_by(
+                case((GenerationJob.status == "running", 0), else_=1),
+                GenerationJob.created_at.desc(),
+            )
             .limit(1)
         )
         latest_job = session.scalars(stmt).first()

--- a/Backend/main.py
+++ b/Backend/main.py
@@ -1,43 +1,26 @@
 import os
-import shutil
-import subprocess
-import threading
-from utils import *
+
 from dotenv import load_dotenv
-
-# Load environment variables
-load_dotenv(ENV_FILE)
-# Check if all required environment variables are set
-# This must happen before importing video which uses API keys without checking
-check_env_vars()
-
-from gpt import *
-from video import *
-from search import *
-from uuid import uuid4
-from tiktokvoice import *
+from flask import Flask, jsonify, request
 from flask_cors import CORS
-from youtube import upload_video
-from apiclient.errors import HttpError
-from flask import Flask, request, jsonify, Response
-from moviepy import AudioFileClip, CompositeAudioClip, VideoFileClip, afx, concatenate_audioclips
-from moviepy.config import change_settings
-from logstream import log, log_stream
+from sqlalchemy import and_, select
+
+from db import SessionLocal, init_db
+from gpt import list_ollama_models
+from logstream import log
+from repository import create_job, get_job, list_job_events, request_cancel
+from utils import ENV_FILE, SONGS_DIR, check_env_vars, clean_dir
 
 
-# Set environment variables
-SESSION_ID = os.getenv("TIKTOK_SESSION_ID")
-change_settings({"IMAGEMAGICK_BINARY": os.environ["IMAGEMAGICK_BINARY"]})
+load_dotenv(ENV_FILE)
+check_env_vars()
+init_db()
 
-# Initialize Flask
 app = Flask(__name__)
 CORS(app)
 
-# Constants
 HOST = "0.0.0.0"
 PORT = 8080
-AMOUNT_OF_STOCK_VIDEOS = 5
-GENERATING = False
 
 
 @app.route("/api/models", methods=["GET"])
@@ -63,396 +46,88 @@ def models():
         )
 
 
-def _run_generation(data: dict) -> None:
-    """Pipeline body — runs in a background thread."""
-    global GENERATING
-    try:
-        paragraph_number = int(data.get("paragraphNumber", 1))
-        ai_model = data.get("aiModel")
-        n_threads = data.get("threads")
-        subtitles_position = data.get("subtitlesPosition")
-        text_color = data.get("color")
-        use_music = data.get("useMusic", False)
-        automate_youtube_upload = data.get("automateYoutubeUpload", False)
-
-        log("[Video to be generated]", "info")
-        log("   Subject: " + data["videoSubject"], "info")
-        log("   AI Model: " + ai_model, "info")
-        log("   Custom Prompt: " + data["customPrompt"], "info")
-
-        if not GENERATING:
-            log_stream.push_event("cancelled", {"message": "Video generation was cancelled."})
-            return
-
-        voice = data["voice"]
-        voice_prefix = voice[:2]
-
-        if not voice:
-            log('[!] No voice was selected. Defaulting to "en_us_001"', "warning")
-            voice = "en_us_001"
-            voice_prefix = voice[:2]
-
-        # Generate a script
-        script = generate_script(
-            data["videoSubject"],
-            paragraph_number,
-            ai_model,
-            voice,
-            data["customPrompt"],
-        )
-
-        if not script:
-            log_stream.push_event("error", {"message": "Could not generate a script. Try a different model or prompt."})
-            return
-
-        # Generate search terms
-        search_terms = get_search_terms(
-            data["videoSubject"], AMOUNT_OF_STOCK_VIDEOS, script, ai_model
-        )
-
-        # Search for a video of the given search term
-        video_urls = []
-        it = 15
-        min_dur = 10
-
-        for search_term in search_terms:
-            if not GENERATING:
-                log_stream.push_event("cancelled", {"message": "Video generation was cancelled."})
-                return
-            found_urls = search_for_stock_videos(
-                search_term, os.getenv("PEXELS_API_KEY"), it, min_dur
-            )
-            for url in found_urls:
-                if url not in video_urls:
-                    video_urls.append(url)
-                    break
-
-        if not video_urls:
-            log("[-] No videos found to download.", "error")
-            log_stream.push_event("error", {"message": "No videos found to download."})
-            return
-
-        video_paths = []
-        log(f"[+] Downloading {len(video_urls)} videos...", "info")
-
-        for video_url in video_urls:
-            if not GENERATING:
-                log_stream.push_event("cancelled", {"message": "Video generation was cancelled."})
-                return
-            try:
-                saved_video_path = save_video(video_url)
-                video_paths.append(saved_video_path)
-            except Exception:
-                log(f"[-] Could not download video: {video_url}", "error")
-
-        log("[+] Videos downloaded!", "success")
-        log("[+] Script generated!\n", "success")
-
-        if not GENERATING:
-            log_stream.push_event("cancelled", {"message": "Video generation was cancelled."})
-            return
-
-        # Split script into sentences
-        sentences = script.split(". ")
-        sentences = list(filter(lambda x: x != "", sentences))
-        paths = []
-
-        for sentence in sentences:
-            if not GENERATING:
-                log_stream.push_event("cancelled", {"message": "Video generation was cancelled."})
-                return
-            current_tts_path = str(TEMP_DIR / f"{uuid4()}.mp3")
-            tts(sentence, voice, filename=current_tts_path)
-            audio_clip = AudioFileClip(current_tts_path)
-            paths.append(audio_clip)
-
-        # Combine all TTS files using moviepy
-        final_audio = concatenate_audioclips(paths)
-        tts_path = str(TEMP_DIR / f"{uuid4()}.mp3")
-        try:
-            final_audio.write_audiofile(tts_path)
-        finally:
-            final_audio.close()
-            for audio_clip in paths:
-                audio_clip.close()
-
-        try:
-            subtitles_path = generate_subtitles(
-                audio_path=tts_path,
-                sentences=sentences,
-                audio_clips=paths,
-                voice=voice_prefix,
-            )
-        except Exception as e:
-            log(f"[-] Error generating subtitles: {e}", "error")
-            subtitles_path = None
-
-        if not subtitles_path:
-            log_stream.push_event("error", {"message": "Could not generate subtitles. Check AssemblyAI key or local subtitle settings."})
-            return
-
-        # Concatenate videos
-        temp_audio = AudioFileClip(tts_path)
-        try:
-            combined_video_path = combine_videos(
-                video_paths, temp_audio.duration, 5, n_threads or 2
-            )
-        finally:
-            temp_audio.close()
-
-        # Put everything together
-        try:
-            final_video_path = generate_video(
-                combined_video_path,
-                tts_path,
-                subtitles_path,
-                n_threads or 2,
-                subtitles_position,
-                text_color or "#FFFF00",
-            )
-        except Exception as e:
-            log(f"[-] Error generating final video: {e}", "error")
-            final_video_path = None
-
-        if not final_video_path:
-            log_stream.push_event("error", {"message": "Could not render final video. Check subtitle/font/ImageMagick setup."})
-            return
-
-        # Generate metadata
-        title, description, keywords = generate_metadata(
-            data["videoSubject"], script, ai_model
-        )
-
-        log("[-] Metadata for YouTube upload:", "info")
-        log("   Title: ", "info")
-        log(f"   {title}", "info")
-        log("   Description: ", "info")
-        log(f"   {description}", "info")
-        log("   Keywords: ", "info")
-        log(f"  {', '.join(keywords)}", "info")
-
-        if automate_youtube_upload:
-            client_secrets_file = str((BASE_DIR / "client_secret.json").resolve())
-            SKIP_YT_UPLOAD = False
-            if not os.path.exists(client_secrets_file):
-                SKIP_YT_UPLOAD = True
-                log("[-] Client secrets file missing. YouTube upload will be skipped.", "warning")
-                log("[-] Please download the client_secret.json from Google Cloud Platform and store this inside the /Backend directory.", "error")
-
-            if not SKIP_YT_UPLOAD:
-                video_category_id = "28"
-                privacyStatus = "private"
-                video_metadata = {
-                    "video_path": str((TEMP_DIR / final_video_path).resolve()),
-                    "title": title,
-                    "description": description,
-                    "category": video_category_id,
-                    "keywords": ",".join(keywords),
-                    "privacyStatus": privacyStatus,
-                }
-
-                try:
-                    video_response = upload_video(
-                        video_path=video_metadata["video_path"],
-                        title=video_metadata["title"],
-                        description=video_metadata["description"],
-                        category=video_metadata["category"],
-                        keywords=video_metadata["keywords"],
-                        privacy_status=video_metadata["privacyStatus"],
-                    )
-                    log(f"Uploaded video ID: {video_response.get('id')}", "success")
-                except HttpError as e:
-                    log(f"An HTTP error {e.resp.status} occurred:\n{e.content}", "error")
-
-        final_output_path = str(PROJECT_ROOT / final_video_path)
-        rendered_video_path = str(TEMP_DIR / final_video_path)
-        render_threads = n_threads or (os.cpu_count() or 2)
-
-        if use_music:
-            song_path = choose_random_song()
-
-            if not song_path:
-                log(
-                    "[-] Could not find songs in Songs/. Continuing without background music.",
-                    "warning",
-                )
-                use_music = False
-
-            if use_music:
-                video_clip = VideoFileClip(rendered_video_path)
-                song_clip = None
-                mixed_audio = None
-                mixed_audio_path = str(TEMP_DIR / f"{uuid4()}_mixed_audio.m4a")
-                try:
-                    original_duration = video_clip.duration
-                    original_audio = video_clip.audio
-                    song_clip = AudioFileClip(song_path).with_fps(44100)
-                    song_clip = song_clip.with_effects(
-                        [afx.AudioLoop(duration=original_duration)]
-                    )
-                    song_clip = song_clip.with_volume_scaled(0.1).with_fps(44100)
-
-                    mixed_audio = CompositeAudioClip(
-                        [original_audio, song_clip]
-                    ).with_duration(original_duration)
-                    mixed_audio.write_audiofile(
-                        mixed_audio_path,
-                        fps=44100,
-                        codec="aac",
-                        bitrate="192k",
-                    )
-                finally:
-                    video_clip.close()
-                    if mixed_audio is not None:
-                        mixed_audio.close()
-                    if song_clip is not None:
-                        song_clip.close()
-
-                try:
-                    # Keep video quality identical by copying the video stream and only replacing audio.
-                    subprocess.run(
-                        [
-                            "ffmpeg",
-                            "-y",
-                            "-i",
-                            rendered_video_path,
-                            "-i",
-                            mixed_audio_path,
-                            "-map",
-                            "0:v:0",
-                            "-map",
-                            "1:a:0",
-                            "-c:v",
-                            "copy",
-                            "-c:a",
-                            "aac",
-                            "-b:a",
-                            "192k",
-                            "-shortest",
-                            final_output_path,
-                        ],
-                        check=True,
-                        capture_output=True,
-                        text=True,
-                    )
-                except Exception:
-                    # Fallback: if ffmpeg CLI isn't available, render through MoviePy.
-                    log(
-                        "[!] ffmpeg remux failed. Falling back to MoviePy render for music mix.",
-                        "warning",
-                    )
-                    video_clip = VideoFileClip(rendered_video_path)
-                    song_clip = None
-                    try:
-                        original_duration = video_clip.duration
-                        original_audio = video_clip.audio
-                        song_clip = AudioFileClip(song_path).with_fps(44100)
-                        song_clip = song_clip.with_effects(
-                            [afx.AudioLoop(duration=original_duration)]
-                        )
-                        song_clip = song_clip.with_volume_scaled(0.1).with_fps(44100)
-                        comp_audio = CompositeAudioClip(
-                            [original_audio, song_clip]
-                        ).with_duration(original_duration)
-                        video_clip = video_clip.with_audio(comp_audio).with_fps(30).with_duration(
-                            original_duration
-                        )
-                        video_clip.write_videofile(
-                            final_output_path,
-                            threads=render_threads,
-                            fps=30,
-                            codec="libx264",
-                            audio_codec="aac",
-                            preset="medium",
-                        )
-                    finally:
-                        video_clip.close()
-                        if song_clip is not None:
-                            song_clip.close()
-                finally:
-                    if os.path.exists(mixed_audio_path):
-                        os.remove(mixed_audio_path)
-
-        if not use_music:
-            # Reuse the already rendered file to avoid a second lossy re-encode.
-            shutil.copy2(rendered_video_path, final_output_path)
-
-        log(f"[+] Video generated: {final_video_path}!", "success")
-
-        # Stop FFMPEG processes
-        if os.name == "nt":
-            subprocess.run(
-                ["taskkill", "/f", "/im", "ffmpeg.exe"],
-                check=False,
-                capture_output=True,
-                text=True,
-            )
-        elif shutil.which("pkill"):
-            subprocess.run(
-                ["pkill", "-f", "ffmpeg"],
-                check=False,
-                capture_output=True,
-                text=True,
-            )
-
-        log_stream.push_event("complete", {
-            "message": "Video generated! See MoneyPrinter/output.mp4 for result.",
-            "data": final_video_path,
-        })
-
-    except Exception as err:
-        log(f"[-] Error: {str(err)}", "error")
-        log_stream.push_event("error", {"message": f"Could not retrieve stock videos: {str(err)}"})
-    finally:
-        GENERATING = False
-
-
-# Generation Endpoint
 @app.route("/api/generate", methods=["POST"])
 def generate():
-    global GENERATING
+    data = request.get_json() or {}
+    if not data.get("videoSubject"):
+        return jsonify({"status": "error", "message": "videoSubject is required."}), 400
 
-    if GENERATING:
-        return jsonify(
-            {
-                "status": "error",
-                "message": "A video is already being generated. Please wait or cancel first.",
-            }
-        ), 409
-
-    GENERATING = True
-
-    # Clean
-    clean_dir(str(TEMP_DIR))
-    clean_dir(str(SUBTITLES_DIR))
-
-    # Clear the log queue before starting
-    log_stream.clear()
-
-    data = request.get_json()
-
-    thread = threading.Thread(target=_run_generation, args=(data,), daemon=True)
-    thread.start()
+    with SessionLocal() as session:
+        job = create_job(session, payload=data)
 
     return jsonify(
         {
             "status": "success",
-            "message": "Video generation started.",
+            "message": "Video generation queued.",
+            "jobId": job.id,
         }
     )
 
 
-@app.route("/api/logs", methods=["GET"])
-def stream_logs():
-    return Response(
-        log_stream.stream(timeout=30.0),
-        mimetype="text/event-stream",
-        headers={
-            "Cache-Control": "no-cache",
-            "X-Accel-Buffering": "no",
-            "Connection": "keep-alive",
-        },
-    )
+@app.route("/api/jobs/<job_id>", methods=["GET"])
+def get_job_status(job_id: str):
+    with SessionLocal() as session:
+        job = get_job(session, job_id)
+        if not job:
+            return jsonify({"status": "error", "message": "Job not found."}), 404
+
+        return jsonify(
+            {
+                "status": "success",
+                "job": {
+                    "id": job.id,
+                    "state": job.status,
+                    "cancelRequested": job.cancel_requested,
+                    "resultPath": job.result_path,
+                    "errorMessage": job.error_message,
+                    "createdAt": job.created_at.isoformat() if job.created_at else None,
+                    "startedAt": job.started_at.isoformat() if job.started_at else None,
+                    "completedAt": job.completed_at.isoformat()
+                    if job.completed_at
+                    else None,
+                },
+            }
+        )
+
+
+@app.route("/api/jobs/<job_id>/events", methods=["GET"])
+def get_events(job_id: str):
+    after_id = request.args.get("after", default=0, type=int)
+
+    with SessionLocal() as session:
+        job = get_job(session, job_id)
+        if not job:
+            return jsonify({"status": "error", "message": "Job not found."}), 404
+
+        events = list_job_events(session, job_id, after_id=after_id)
+        return jsonify(
+            {
+                "status": "success",
+                "events": [
+                    {
+                        "id": event.id,
+                        "type": event.event_type,
+                        "level": event.level,
+                        "message": event.message,
+                        "payload": event.payload,
+                        "timestamp": event.created_at.timestamp()
+                        if event.created_at
+                        else None,
+                    }
+                    for event in events
+                ],
+            }
+        )
+
+
+@app.route("/api/jobs/<job_id>/cancel", methods=["POST"])
+def cancel_job(job_id: str):
+    with SessionLocal() as session:
+        cancelled = request_cancel(session, job_id)
+        if not cancelled:
+            return jsonify({"status": "error", "message": "Job not found."}), 404
+
+    return jsonify({"status": "success", "message": "Cancellation requested."})
 
 
 @app.route("/api/upload-songs", methods=["POST"])
@@ -462,13 +137,12 @@ def upload_songs():
         if not files:
             return jsonify({"status": "error", "message": "No files uploaded."}), 400
 
-        # Clear existing songs and save new ones
         clean_dir(str(SONGS_DIR))
         saved = 0
-        for f in files:
-            if f.filename and f.filename.lower().endswith(".mp3"):
-                safe_name = os.path.basename(f.filename)
-                f.save(str(SONGS_DIR / safe_name))
+        for file_item in files:
+            if file_item.filename and file_item.filename.lower().endswith(".mp3"):
+                safe_name = os.path.basename(file_item.filename)
+                file_item.save(str(SONGS_DIR / safe_name))
                 saved += 1
 
         if saved == 0:
@@ -482,15 +156,30 @@ def upload_songs():
 
 
 @app.route("/api/cancel", methods=["POST"])
-def cancel():
-    log("[!] Received cancellation request...", "warning")
+def cancel_latest_running_job():
+    with SessionLocal() as session:
+        from models import GenerationJob
 
-    global GENERATING
-    GENERATING = False
+        stmt = (
+            select(GenerationJob)
+            .where(and_(GenerationJob.status.in_(["queued", "running"])))
+            .order_by(GenerationJob.created_at.desc())
+            .limit(1)
+        )
+        latest_job = session.scalars(stmt).first()
+        if not latest_job:
+            return jsonify({"status": "error", "message": "No active job found."}), 404
 
-    return jsonify({"status": "success", "message": "Cancelled video generation."})
+        request_cancel(session, latest_job.id)
+
+    return jsonify(
+        {
+            "status": "success",
+            "message": "Cancellation requested.",
+            "jobId": latest_job.id,
+        }
+    )
 
 
 if __name__ == "__main__":
-    # Run Flask App
     app.run(debug=True, host=HOST, port=PORT, threaded=True)

--- a/Backend/models.py
+++ b/Backend/models.py
@@ -1,0 +1,114 @@
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, JSON, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from db import Base
+
+
+class Project(Base):
+    __tablename__ = "projects"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+
+class GenerationJob(Base):
+    __tablename__ = "generation_jobs"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    project_id: Mapped[Optional[int]] = mapped_column(
+        Integer,
+        ForeignKey("projects.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    status: Mapped[str] = mapped_column(String(20), nullable=False, index=True)
+    payload: Mapped[dict] = mapped_column(JSON, nullable=False)
+    cancel_requested: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False
+    )
+    attempt_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    max_attempts: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    result_path: Mapped[Optional[str]] = mapped_column(String(512), nullable=True)
+    error_message: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False, index=True
+    )
+    started_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    completed_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    project: Mapped[Optional[Project]] = relationship("Project")
+    events: Mapped[list["GenerationEvent"]] = relationship(
+        "GenerationEvent", back_populates="job", cascade="all, delete-orphan"
+    )
+
+
+class GenerationEvent(Base):
+    __tablename__ = "generation_events"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    job_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("generation_jobs.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    event_type: Mapped[str] = mapped_column(String(20), nullable=False, default="log")
+    level: Mapped[str] = mapped_column(String(20), nullable=False, default="info")
+    message: Mapped[str] = mapped_column(Text, nullable=False)
+    payload: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False, index=True
+    )
+
+    job: Mapped[GenerationJob] = relationship("GenerationJob", back_populates="events")
+
+
+class Script(Base):
+    __tablename__ = "scripts"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    job_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("generation_jobs.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    model_name: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+
+class Artifact(Base):
+    __tablename__ = "artifacts"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    job_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("generation_jobs.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    artifact_type: Mapped[str] = mapped_column(String(64), nullable=False)
+    path: Mapped[str] = mapped_column(String(512), nullable=False)
+    metadata_json: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/Backend/pipeline.py
+++ b/Backend/pipeline.py
@@ -1,0 +1,365 @@
+import os
+import shutil
+import subprocess
+
+from apiclient.errors import HttpError
+from moviepy import (
+    AudioFileClip,
+    CompositeAudioClip,
+    VideoFileClip,
+    afx,
+    concatenate_audioclips,
+)
+from uuid import uuid4
+
+from gpt import generate_metadata, generate_script, get_search_terms
+from logstream import log
+from search import search_for_stock_videos
+from tiktokvoice import tts
+from utils import (
+    BASE_DIR,
+    PROJECT_ROOT,
+    SONGS_DIR,
+    SUBTITLES_DIR,
+    TEMP_DIR,
+    choose_random_song,
+)
+from video import combine_videos, generate_subtitles, generate_video, save_video
+from youtube import upload_video
+
+
+class PipelineCancelled(Exception):
+    pass
+
+
+def run_generation_pipeline(
+    data: dict,
+    is_cancelled,
+    on_log,
+    amount_of_stock_videos: int = 5,
+) -> str:
+    def emit(message: str, level: str = "info") -> None:
+        log(message, level)
+        if on_log:
+            on_log(message, level)
+
+    def guard_cancelled() -> None:
+        if is_cancelled and is_cancelled():
+            raise PipelineCancelled("Video generation was cancelled.")
+
+    paragraph_number = int(data.get("paragraphNumber", 1))
+    ai_model = data.get("aiModel")
+    n_threads = data.get("threads")
+    subtitles_position = data.get("subtitlesPosition")
+    text_color = data.get("color")
+    use_music = data.get("useMusic", False)
+    automate_youtube_upload = data.get("automateYoutubeUpload", False)
+
+    emit("[Video to be generated]", "info")
+    emit("   Subject: " + data["videoSubject"], "info")
+    emit("   AI Model: " + str(ai_model), "info")
+    emit("   Custom Prompt: " + data["customPrompt"], "info")
+
+    guard_cancelled()
+
+    voice = data.get("voice", "")
+    voice_prefix = voice[:2]
+
+    if not voice:
+        emit('[!] No voice was selected. Defaulting to "en_us_001"', "warning")
+        voice = "en_us_001"
+        voice_prefix = voice[:2]
+
+    script = generate_script(
+        data["videoSubject"],
+        paragraph_number,
+        ai_model,
+        voice,
+        data["customPrompt"],
+    )
+
+    if not script:
+        raise RuntimeError(
+            "Could not generate a script. Try a different model or prompt."
+        )
+
+    search_terms = get_search_terms(
+        data["videoSubject"], amount_of_stock_videos, script, ai_model
+    )
+
+    video_urls = []
+    it = 15
+    min_dur = 10
+
+    for search_term in search_terms:
+        guard_cancelled()
+        found_urls = search_for_stock_videos(
+            search_term, os.getenv("PEXELS_API_KEY"), it, min_dur
+        )
+        for url in found_urls:
+            if url not in video_urls:
+                video_urls.append(url)
+                break
+
+    if not video_urls:
+        raise RuntimeError("No videos found to download.")
+
+    video_paths = []
+    emit(f"[+] Downloading {len(video_urls)} videos...", "info")
+
+    for video_url in video_urls:
+        guard_cancelled()
+        try:
+            saved_video_path = save_video(video_url)
+            video_paths.append(saved_video_path)
+        except Exception:
+            emit(f"[-] Could not download video: {video_url}", "error")
+
+    emit("[+] Videos downloaded!", "success")
+    emit("[+] Script generated!", "success")
+
+    guard_cancelled()
+
+    sentences = script.split(". ")
+    sentences = list(filter(lambda x: x != "", sentences))
+    paths = []
+
+    for sentence in sentences:
+        guard_cancelled()
+        current_tts_path = str(TEMP_DIR / f"{uuid4()}.mp3")
+        tts(sentence, voice, filename=current_tts_path)
+        audio_clip = AudioFileClip(current_tts_path)
+        paths.append(audio_clip)
+
+    final_audio = concatenate_audioclips(paths)
+    tts_path = str(TEMP_DIR / f"{uuid4()}.mp3")
+    try:
+        final_audio.write_audiofile(tts_path)
+    finally:
+        final_audio.close()
+        for audio_clip in paths:
+            audio_clip.close()
+
+    try:
+        subtitles_path = generate_subtitles(
+            audio_path=tts_path,
+            sentences=sentences,
+            audio_clips=paths,
+            voice=voice_prefix,
+        )
+    except Exception as err:
+        emit(f"[-] Error generating subtitles: {err}", "error")
+        subtitles_path = None
+
+    if not subtitles_path:
+        raise RuntimeError(
+            "Could not generate subtitles. Check AssemblyAI key or local subtitle settings."
+        )
+
+    temp_audio = AudioFileClip(tts_path)
+    try:
+        combined_video_path = combine_videos(
+            video_paths, temp_audio.duration, 5, n_threads or 2
+        )
+    finally:
+        temp_audio.close()
+
+    try:
+        final_video_path = generate_video(
+            combined_video_path,
+            tts_path,
+            subtitles_path,
+            n_threads or 2,
+            subtitles_position,
+            text_color or "#FFFF00",
+        )
+    except Exception as err:
+        raise RuntimeError(
+            f"Could not render final video. Check subtitle/font/ImageMagick setup. ({err})"
+        ) from err
+
+    title, description, keywords = generate_metadata(
+        data["videoSubject"], script, ai_model
+    )
+
+    emit("[-] Metadata for YouTube upload:", "info")
+    emit("   Title:", "info")
+    emit(f"   {title}", "info")
+    emit("   Description:", "info")
+    emit(f"   {description}", "info")
+    emit("   Keywords:", "info")
+    emit(f"  {', '.join(keywords)}", "info")
+
+    if automate_youtube_upload:
+        client_secrets_file = str((BASE_DIR / "client_secret.json").resolve())
+        skip_yt_upload = False
+        if not os.path.exists(client_secrets_file):
+            skip_yt_upload = True
+            emit(
+                "[-] Client secrets file missing. YouTube upload will be skipped.",
+                "warning",
+            )
+            emit(
+                "[-] Please download the client_secret.json from Google Cloud Platform and store this inside the /Backend directory.",
+                "error",
+            )
+
+        if not skip_yt_upload:
+            video_category_id = "28"
+            privacy_status = "private"
+            video_metadata = {
+                "video_path": str((TEMP_DIR / final_video_path).resolve()),
+                "title": title,
+                "description": description,
+                "category": video_category_id,
+                "keywords": ",".join(keywords),
+                "privacyStatus": privacy_status,
+            }
+
+            try:
+                video_response = upload_video(
+                    video_path=video_metadata["video_path"],
+                    title=video_metadata["title"],
+                    description=video_metadata["description"],
+                    category=video_metadata["category"],
+                    keywords=video_metadata["keywords"],
+                    privacy_status=video_metadata["privacyStatus"],
+                )
+                emit(f"Uploaded video ID: {video_response.get('id')}", "success")
+            except HttpError as err:
+                emit(
+                    f"An HTTP error {err.resp.status} occurred:\n{err.content}", "error"
+                )
+
+    final_output_path = str(PROJECT_ROOT / final_video_path)
+    rendered_video_path = str(TEMP_DIR / final_video_path)
+    render_threads = n_threads or (os.cpu_count() or 2)
+
+    guard_cancelled()
+
+    if use_music:
+        song_path = choose_random_song()
+
+        if not song_path:
+            emit(
+                "[-] Could not find songs in Songs/. Continuing without background music.",
+                "warning",
+            )
+            use_music = False
+
+        if use_music:
+            video_clip = VideoFileClip(rendered_video_path)
+            song_clip = None
+            mixed_audio = None
+            mixed_audio_path = str(TEMP_DIR / f"{uuid4()}_mixed_audio.m4a")
+            try:
+                original_duration = video_clip.duration
+                original_audio = video_clip.audio
+                song_clip = AudioFileClip(song_path).with_fps(44100)
+                song_clip = song_clip.with_effects(
+                    [afx.AudioLoop(duration=original_duration)]
+                )
+                song_clip = song_clip.with_volume_scaled(0.1).with_fps(44100)
+
+                mixed_audio = CompositeAudioClip(
+                    [original_audio, song_clip]
+                ).with_duration(original_duration)
+                mixed_audio.write_audiofile(
+                    mixed_audio_path,
+                    fps=44100,
+                    codec="aac",
+                    bitrate="192k",
+                )
+            finally:
+                video_clip.close()
+                if mixed_audio is not None:
+                    mixed_audio.close()
+                if song_clip is not None:
+                    song_clip.close()
+
+            try:
+                subprocess.run(
+                    [
+                        "ffmpeg",
+                        "-y",
+                        "-i",
+                        rendered_video_path,
+                        "-i",
+                        mixed_audio_path,
+                        "-map",
+                        "0:v:0",
+                        "-map",
+                        "1:a:0",
+                        "-c:v",
+                        "copy",
+                        "-c:a",
+                        "aac",
+                        "-b:a",
+                        "192k",
+                        "-shortest",
+                        final_output_path,
+                    ],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
+            except Exception:
+                emit(
+                    "[!] ffmpeg remux failed. Falling back to MoviePy render for music mix.",
+                    "warning",
+                )
+                video_clip = VideoFileClip(rendered_video_path)
+                song_clip = None
+                try:
+                    original_duration = video_clip.duration
+                    original_audio = video_clip.audio
+                    song_clip = AudioFileClip(song_path).with_fps(44100)
+                    song_clip = song_clip.with_effects(
+                        [afx.AudioLoop(duration=original_duration)]
+                    )
+                    song_clip = song_clip.with_volume_scaled(0.1).with_fps(44100)
+                    comp_audio = CompositeAudioClip(
+                        [original_audio, song_clip]
+                    ).with_duration(original_duration)
+                    video_clip = (
+                        video_clip.with_audio(comp_audio)
+                        .with_fps(30)
+                        .with_duration(original_duration)
+                    )
+                    video_clip.write_videofile(
+                        final_output_path,
+                        threads=render_threads,
+                        fps=30,
+                        codec="libx264",
+                        audio_codec="aac",
+                        preset="medium",
+                    )
+                finally:
+                    video_clip.close()
+                    if song_clip is not None:
+                        song_clip.close()
+            finally:
+                if os.path.exists(mixed_audio_path):
+                    os.remove(mixed_audio_path)
+
+    if not use_music:
+        shutil.copy2(rendered_video_path, final_output_path)
+
+    emit(f"[+] Video generated: {final_video_path}!", "success")
+
+    if os.name == "nt":
+        subprocess.run(
+            ["taskkill", "/f", "/im", "ffmpeg.exe"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    elif shutil.which("pkill"):
+        subprocess.run(
+            ["pkill", "-f", "ffmpeg"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    return final_video_path

--- a/Backend/repository.py
+++ b/Backend/repository.py
@@ -1,0 +1,185 @@
+from datetime import datetime, timezone
+from typing import Optional
+from uuid import uuid4
+
+from sqlalchemy import and_, select, text
+from sqlalchemy.orm import Session
+
+from models import GenerationEvent, GenerationJob
+
+
+def utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def create_job(session: Session, payload: dict, max_attempts: int = 1) -> GenerationJob:
+    job = GenerationJob(
+        id=str(uuid4()),
+        status="queued",
+        payload=payload,
+        max_attempts=max_attempts,
+        cancel_requested=False,
+    )
+    session.add(job)
+    session.flush()
+    append_event(session, job.id, "queued", "info", "Job queued.")
+    session.commit()
+    session.refresh(job)
+    return job
+
+
+def append_event(
+    session: Session,
+    job_id: str,
+    event_type: str,
+    level: str,
+    message: str,
+    payload: Optional[dict] = None,
+) -> GenerationEvent:
+    event = GenerationEvent(
+        job_id=job_id,
+        event_type=event_type,
+        level=level,
+        message=message,
+        payload=payload,
+    )
+    session.add(event)
+    session.flush()
+    return event
+
+
+def get_job(session: Session, job_id: str) -> Optional[GenerationJob]:
+    return session.get(GenerationJob, job_id)
+
+
+def list_job_events(
+    session: Session, job_id: str, after_id: int = 0, limit: int = 200
+) -> list[GenerationEvent]:
+    stmt = (
+        select(GenerationEvent)
+        .where(
+            and_(
+                GenerationEvent.job_id == job_id,
+                GenerationEvent.id > after_id,
+            )
+        )
+        .order_by(GenerationEvent.id.asc())
+        .limit(limit)
+    )
+    return list(session.scalars(stmt).all())
+
+
+def request_cancel(session: Session, job_id: str) -> bool:
+    job = get_job(session, job_id)
+    if not job:
+        return False
+
+    if job.status in ("completed", "failed", "cancelled"):
+        return True
+
+    job.cancel_requested = True
+    job.updated_at = utcnow()
+    append_event(
+        session, job.id, "cancel_requested", "warning", "Cancellation requested."
+    )
+
+    if job.status == "queued":
+        job.status = "cancelled"
+        job.completed_at = utcnow()
+        append_event(
+            session, job.id, "cancelled", "warning", "Job cancelled before execution."
+        )
+
+    session.commit()
+    return True
+
+
+def claim_next_queued_job(session: Session) -> Optional[GenerationJob]:
+    dialect = session.bind.dialect.name if session.bind else ""
+
+    if dialect == "postgresql":
+        row = session.execute(
+            text(
+                """
+                SELECT id
+                FROM generation_jobs
+                WHERE status = 'queued' AND cancel_requested = false
+                ORDER BY created_at ASC
+                FOR UPDATE SKIP LOCKED
+                LIMIT 1
+                """
+            )
+        ).first()
+        if not row:
+            return None
+        job = get_job(session, row[0])
+    else:
+        stmt = (
+            select(GenerationJob)
+            .where(
+                and_(
+                    GenerationJob.status == "queued",
+                    GenerationJob.cancel_requested.is_(False),
+                )
+            )
+            .order_by(GenerationJob.created_at.asc())
+            .limit(1)
+        )
+        job = session.scalars(stmt).first()
+
+    if not job:
+        return None
+
+    job.status = "running"
+    job.attempt_count = (job.attempt_count or 0) + 1
+    job.started_at = utcnow()
+    job.updated_at = utcnow()
+    append_event(session, job.id, "running", "info", "Job started.")
+    session.commit()
+    session.refresh(job)
+    return job
+
+
+def mark_completed(session: Session, job_id: str, result_path: str) -> None:
+    job = get_job(session, job_id)
+    if not job:
+        return
+    job.status = "completed"
+    job.result_path = result_path
+    job.error_message = None
+    job.completed_at = utcnow()
+    job.updated_at = utcnow()
+    append_event(
+        session,
+        job.id,
+        "complete",
+        "success",
+        "Video generated successfully.",
+        {"path": result_path},
+    )
+    session.commit()
+
+
+def mark_cancelled(
+    session: Session, job_id: str, reason: str = "Job cancelled."
+) -> None:
+    job = get_job(session, job_id)
+    if not job:
+        return
+    job.status = "cancelled"
+    job.completed_at = utcnow()
+    job.updated_at = utcnow()
+    append_event(session, job.id, "cancelled", "warning", reason)
+    session.commit()
+
+
+def mark_failed(session: Session, job_id: str, error_message: str) -> None:
+    job = get_job(session, job_id)
+    if not job:
+        return
+    job.status = "failed"
+    job.error_message = error_message
+    job.completed_at = utcnow()
+    job.updated_at = utcnow()
+    append_event(session, job.id, "error", "error", error_message)
+    session.commit()

--- a/Backend/worker.py
+++ b/Backend/worker.py
@@ -1,0 +1,77 @@
+import time
+
+from dotenv import load_dotenv
+
+from db import SessionLocal, init_db
+from pipeline import PipelineCancelled, run_generation_pipeline
+from repository import (
+    append_event,
+    claim_next_queued_job,
+    get_job,
+    mark_cancelled,
+    mark_completed,
+    mark_failed,
+)
+from utils import ENV_FILE, SUBTITLES_DIR, TEMP_DIR, check_env_vars, clean_dir
+
+
+POLL_SECONDS = 1.0
+
+
+def _job_cancelled(job_id: str) -> bool:
+    with SessionLocal() as session:
+        job = get_job(session, job_id)
+        if not job:
+            return True
+        return bool(job.cancel_requested or job.status == "cancelled")
+
+
+def _log_event(job_id: str, message: str, level: str) -> None:
+    with SessionLocal() as session:
+        append_event(session, job_id, "log", level, str(message))
+        session.commit()
+
+
+def process_next_job() -> bool:
+    with SessionLocal() as session:
+        job = claim_next_queued_job(session)
+
+    if not job:
+        return False
+
+    job_id = job.id
+
+    clean_dir(str(TEMP_DIR))
+    clean_dir(str(SUBTITLES_DIR))
+
+    try:
+        result_path = run_generation_pipeline(
+            data=job.payload,
+            is_cancelled=lambda: _job_cancelled(job_id),
+            on_log=lambda message, level: _log_event(job_id, message, level),
+        )
+        with SessionLocal() as session:
+            mark_completed(session, job_id, result_path)
+    except PipelineCancelled as err:
+        with SessionLocal() as session:
+            mark_cancelled(session, job_id, str(err))
+    except Exception as err:
+        with SessionLocal() as session:
+            mark_failed(session, job_id, str(err))
+
+    return True
+
+
+def main() -> None:
+    load_dotenv(ENV_FILE)
+    check_env_vars()
+    init_db()
+
+    while True:
+        processed = process_next_job()
+        if not processed:
+            time.sleep(POLL_SECONDS)
+
+
+if __name__ == "__main__":
+    main()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,13 +18,14 @@ ollama pull llama3.1:8b     # pull default model
 
 ### Run (local)
 ```bash
-uv run python Backend/main.py                              # backend on :8080
+uv run python Backend/main.py                              # API on :8080
+uv run python Backend/worker.py                            # queue worker
 python3 -m http.server 3000 --directory Frontend           # frontend on :3000
 ```
 
 ### Run (Docker)
 ```bash
-docker compose up --build   # frontend :8001, backend :8080
+docker compose up --build   # frontend :8001, backend :8080, postgres :5432
 ```
 
 ### Verify
@@ -45,7 +46,8 @@ uv run pytest tests/test_file.py::test_name -q             # single test
 ### Video Generation Pipeline (end-to-end flow)
 
 ```
-User input (Frontend) → POST /api/generate → Background thread in main.py
+User input (Frontend) → POST /api/generate → generation_jobs (Postgres queue)
+  → worker.py claims queued job
   → gpt.py: generate_script() via Ollama
   → gpt.py: get_search_terms() → JSON keywords
   → search.py: Pexels API → download stock clips to temp/
@@ -59,24 +61,26 @@ User input (Frontend) → POST /api/generate → Background thread in main.py
 ```
 
 ### Frontend ↔ Backend Communication
-- **REST**: JSON payloads to Flask endpoints (`/api/generate`, `/api/cancel`, `/api/models`, `/api/upload-songs`)
-- **SSE**: Real-time log streaming via `/api/logs` (logstream.py). Event types: `log`, `complete`, `error`, `cancelled`
+- **REST**: JSON payloads to Flask endpoints (`/api/generate`, `/api/jobs/:id`, `/api/jobs/:id/events`, `/api/jobs/:id/cancel`, `/api/models`, `/api/upload-songs`)
+- **Polling**: frontend polls job status and persisted generation events.
 
 ### Key Backend Modules
 | File | Responsibility |
 |------|---------------|
-| `main.py` | Flask app, API endpoints, generation orchestration (background thread) |
+| `main.py` | Flask app and queue/job endpoints |
+| `worker.py` | Job consumer that executes generation pipeline |
+| `db.py`/`models.py`/`repository.py` | DB engine, schema, queue/event persistence |
 | `gpt.py` | Ollama client: script generation, search terms, YouTube metadata |
 | `video.py` | Video processing: combine clips, burn subtitles, merge audio |
 | `search.py` | Pexels stock video search and download |
 | `tiktokvoice.py` | TikTok TTS API (60+ voices, 300-char chunking, threaded) |
 | `youtube.py` | YouTube upload via Google API with OAuth2 |
 | `utils.py` | Path constants, env validation, ImageMagick detection |
-| `logstream.py` | Thread-safe SSE log queue |
+| `pipeline.py` | Reusable generation pipeline used by worker |
 
 ### Frontend
 - `index.html`: UI with inline CSS, form fields, live log viewer
-- `app.js`: API client (`apiRequest()`), SSE log stream, localStorage persistence
+- `app.js`: API client (`apiRequest()`), job polling UI, localStorage persistence
 
 ### Runtime Directories
 - `temp/`: intermediate video/audio files (cleared each generation)
@@ -90,13 +94,13 @@ User input (Frontend) → POST /api/generate → Background thread in main.py
 - `PEXELS_API_KEY` — stock video API
 - `IMAGEMAGICK_BINARY` — leave empty to auto-detect from PATH
 
-Optional: `OLLAMA_BASE_URL`, `OLLAMA_MODEL`, `ASSEMBLY_AI_API_KEY`
+Optional: `OLLAMA_BASE_URL`, `OLLAMA_MODEL`, `ASSEMBLY_AI_API_KEY`, `DATABASE_URL`
 
 ## Conventions
 
 - **Python**: 4-space indent, `snake_case`, type hints on all new/modified signatures, `pathlib.Path` for filesystem ops
 - **JS**: `camelCase`, centralized API calls via `apiRequest()`
 - **API responses**: `{"status": "success|error", ...}` with proper HTTP codes
-- **Long-running work**: background thread pattern with global `GENERATING` flag, SSE streaming
-- **Concurrency**: only one video generation at a time (enforced by `GENERATING` flag)
+- **Long-running work**: database-backed queue and separate worker process
+- **Concurrency**: multiple jobs can be queued; worker processes them safely via DB locking
 - Update `docs/` when setup, env vars, or runtime behavior changes

--- a/Frontend/app.js
+++ b/Frontend/app.js
@@ -22,7 +22,9 @@ const backendProtocol = window.location.protocol || "http:";
 const API_BASE_URL = `${backendProtocol}//${backendHost}:8080`;
 const API_FALLBACK_URL = `http://${backendHost}:8080`;
 
-let eventSource = null;
+let activeJobId = null;
+let pollHandle = null;
+let lastEventId = 0;
 
 // ===== API HELPERS =====
 async function apiRequest(path, options = {}) {
@@ -148,7 +150,7 @@ advancedOptionsToggle.addEventListener("click", () => {
 
 // ===== LOG STREAM (SSE) =====
 function formatTimestamp(ts) {
-  const d = new Date(ts * 1000);
+  const d = new Date((ts || Date.now() / 1000) * 1000);
   return d.toLocaleTimeString("en-GB", { hour12: false });
 }
 
@@ -172,51 +174,66 @@ function appendLogEntry(entry) {
   logViewerBody.scrollTop = logViewerBody.scrollHeight;
 }
 
-function connectLogStream() {
-  disconnectLogStream();
+async function pollJob() {
+  if (!activeJobId) return;
 
-  logViewer.classList.add("active");
+  try {
+    const eventsResult = await apiRequest(`/api/jobs/${activeJobId}/events?after=${lastEventId}`, {
+      method: "GET",
+      headers: {
+        Accept: "application/json",
+      },
+    });
 
-  const url = `${API_BASE_URL}/api/logs`;
-  eventSource = new EventSource(url);
+    const events = Array.isArray(eventsResult.events) ? eventsResult.events : [];
+    events.forEach((event) => {
+      appendLogEntry({
+        timestamp: event.timestamp,
+        message: event.message,
+        level: event.level || "info",
+      });
+      lastEventId = Math.max(lastEventId, event.id || 0);
+    });
 
-  eventSource.onmessage = (event) => {
-    let entry;
-    try {
-      entry = JSON.parse(event.data);
-    } catch {
-      return;
-    }
+    const jobResult = await apiRequest(`/api/jobs/${activeJobId}`, {
+      method: "GET",
+      headers: {
+        Accept: "application/json",
+      },
+    });
 
-    if (entry.type === "log") {
-      appendLogEntry(entry);
-    } else if (entry.type === "complete") {
-      appendLogEntry({ timestamp: entry.timestamp, message: entry.message, level: "success" });
-      showToast(entry.message, "success");
+    const state = jobResult?.job?.state;
+    if (state === "completed") {
+      showToast("Video generated successfully.", "success");
+      stopJobPolling();
       setGeneratingState(false);
-      disconnectLogStream();
-    } else if (entry.type === "error") {
-      appendLogEntry({ timestamp: entry.timestamp, message: entry.message, level: "error" });
-      showToast(entry.message, "error");
+    } else if (state === "failed") {
+      showToast(jobResult?.job?.errorMessage || "Generation failed.", "error");
+      stopJobPolling();
       setGeneratingState(false);
-      disconnectLogStream();
-    } else if (entry.type === "cancelled") {
-      appendLogEntry({ timestamp: entry.timestamp, message: entry.message || "Generation cancelled.", level: "warning" });
-      disconnectLogStream();
+    } else if (state === "cancelled") {
+      showToast("Generation cancelled.", "warning");
+      stopJobPolling();
+      setGeneratingState(false);
     }
-  };
-
-  eventSource.onerror = () => {
-    // Connection lost — will auto-reconnect via EventSource spec,
-    // but if generation is done the server closed the stream.
-    // No action needed; terminal events above handle cleanup.
-  };
+  } catch {
+    // Ignore transient polling failures.
+  }
 }
 
-function disconnectLogStream() {
-  if (eventSource) {
-    eventSource.close();
-    eventSource = null;
+function startJobPolling(jobId) {
+  stopJobPolling();
+  activeJobId = jobId;
+  lastEventId = 0;
+  logViewer.classList.add("active");
+  pollHandle = setInterval(pollJob, 1200);
+  pollJob();
+}
+
+function stopJobPolling() {
+  if (pollHandle) {
+    clearInterval(pollHandle);
+    pollHandle = null;
   }
 }
 
@@ -227,6 +244,8 @@ function setGeneratingState(active) {
     cancelButton.classList.remove("hidden");
     statusArea.classList.add("active");
   } else {
+    stopJobPolling();
+    activeJobId = null;
     generateButton.classList.remove("hidden");
     cancelButton.classList.add("hidden");
     statusArea.classList.remove("active");
@@ -236,9 +255,9 @@ function setGeneratingState(active) {
 }
 
 function cancelGeneration() {
-  disconnectLogStream();
+  const targetPath = activeJobId ? `/api/jobs/${activeJobId}/cancel` : "/api/cancel";
 
-  apiRequest("/api/cancel", {
+  apiRequest(targetPath, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -247,8 +266,6 @@ function cancelGeneration() {
   })
     .then((data) => showToast(data.message, "success"))
     .catch(() => showToast("Failed to cancel. Is the server running?", "error"));
-
-  setGeneratingState(false);
 }
 
 async function uploadSongs() {
@@ -323,8 +340,12 @@ async function generateVideo() {
     });
 
     if (result.status === "success") {
-      // Generation started — connect to the log stream
-      connectLogStream();
+      if (!result.jobId) {
+        showToast("Generation queued, but no job ID was returned.", "error");
+        setGeneratingState(false);
+        return;
+      }
+      startJobPolling(result.jobId);
     } else {
       showToast(result.message, "error");
       setGeneratingState(false);

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Automate the creation of YouTube Shorts by providing a video topic.
 
 MoneyPrinter is Ollama-first: script generation and metadata are fully powered by local Ollama models.
 
+MoneyPrinter now uses a DB-backed generation queue (API + worker + Postgres in Docker) for reliable, restart-safe processing.
+
 <a href="https://trendshift.io/repositories/7545" target="_blank"><img src="https://trendshift.io/api/badge/repositories/7545" alt="FujiwaraChoki%2FMoneyPrinter | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 
 > **Important** Please make sure you look through existing/closed issues before opening your own. If it's just a question, please join our [discord](https://dsc.gg/fuji-community) and ask there.
@@ -19,9 +21,12 @@ MoneyPrinter is Ollama-first: script generation and metadata are fully powered b
 
 Docs are centralized in [`docs/`](docs/README.md):
 
+- [Interactive Setup Script](setup.sh)
 - [Quickstart](docs/quickstart.md)
 - [Configuration](docs/configuration.md)
+- [Architecture](docs/architecture.md)
 - [Docker](docs/docker.md)
+- [Testing](docs/testing.md)
 - [Troubleshooting](docs/troubleshooting.md)
 
 ## FAQ 🤔

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,23 @@
 version: "3"
 services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: "postgres"
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_DB=${POSTGRES_DB:-moneyprinter}
+      - POSTGRES_USER=${POSTGRES_USER:-moneyprinter}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-moneyprinter}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-moneyprinter} -d ${POSTGRES_DB:-moneyprinter}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    restart: always
+
   frontend:
     build:
       context: .
@@ -30,11 +48,40 @@ services:
       - PEXELS_API_KEY=${PEXELS_API_KEY}
       - OLLAMA_BASE_URL=${OLLAMA_BASE_URL:-http://host.docker.internal:11434}
       - OLLAMA_MODEL=${OLLAMA_MODEL:-llama3.1:8b}
+      - DATABASE_URL=${DATABASE_URL:-postgresql+psycopg://moneyprinter:moneyprinter@postgres:5432/moneyprinter}
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
+      - frontend
+      - postgres
+    restart: always
+
+  worker:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: "worker"
+    command: ["python3", "backend/worker.py"]
+    volumes:
+      - ./files:/temp
+      - ./Backend:/app/backend
+      - ./fonts:/app/fonts
+    environment:
+      - ASSEMBLY_AI_API_KEY=${ASSEMBLY_AI_API_KEY}
+      - TIKTOK_SESSION_ID=${TIKTOK_SESSION_ID}
+      - IMAGEMAGICK_BINARY=/usr/local/bin/magick
+      - PEXELS_API_KEY=${PEXELS_API_KEY}
+      - OLLAMA_BASE_URL=${OLLAMA_BASE_URL:-http://host.docker.internal:11434}
+      - OLLAMA_MODEL=${OLLAMA_MODEL:-llama3.1:8b}
+      - DATABASE_URL=${DATABASE_URL:-postgresql+psycopg://moneyprinter:moneyprinter@postgres:5432/moneyprinter}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    depends_on:
+      - postgres
+      - backend
       - frontend
     restart: always
 
 volumes:
   files:
+  postgres_data:

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,9 +4,12 @@ This folder is the single source of truth for setup, configuration, and troubles
 
 ## Start Here
 
+- [Interactive Setup Script](../setup.sh)
 - [Quickstart](quickstart.md)
 - [Configuration](configuration.md)
+- [Architecture](architecture.md)
 - [Docker](docker.md)
+- [Testing](testing.md)
 - [Troubleshooting](troubleshooting.md)
 
 ## Recommended Reading Order
@@ -14,4 +17,5 @@ This folder is the single source of truth for setup, configuration, and troubles
 1. Quickstart
 2. Configuration
 3. Docker (if you use containers)
-4. Troubleshooting (when something breaks)
+4. Testing
+5. Troubleshooting (when something breaks)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,167 @@
+# Architecture
+
+MoneyPrinter now uses a database-backed queue architecture designed for reliability, restart safety, and future scaling.
+
+## Overview
+
+- `Frontend` submits generation requests and polls job status/events.
+- `API (Flask)` validates input and enqueues jobs in Postgres.
+- `Worker` claims queued jobs and runs the generation pipeline.
+- `Postgres` is the source of truth for job state, progress events, and artifacts.
+
+```mermaid
+flowchart LR
+    U[User] --> F[Frontend\nindex.html + app.js]
+    F -->|POST /api/generate| A[API\nBackend/main.py]
+    F -->|GET /api/jobs/:id| A
+    F -->|GET /api/jobs/:id/events| A
+    F -->|POST /api/jobs/:id/cancel| A
+
+    A -->|insert job| DB[(Postgres)]
+    A -->|read status/events| DB
+
+    W[Worker\nBackend/worker.py] -->|claim queued job| DB
+    W -->|write logs/events| DB
+    W -->|update final state| DB
+    W --> P[Pipeline\nBackend/pipeline.py]
+    P --> FS[(temp/subtitles/output files)]
+```
+
+## Runtime Services (Docker)
+
+```mermaid
+flowchart TB
+    subgraph Compose
+      FE[frontend]
+      API[backend]
+      WK[worker]
+      PG[(postgres)]
+    end
+
+    FE --> API
+    API --> PG
+    WK --> PG
+    WK --> API
+```
+
+## Generation Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> queued
+    queued --> running: worker claims job
+    queued --> cancelled: cancel before claim
+    running --> completed: success
+    running --> failed: unrecoverable error
+    running --> cancelled: cancellation requested
+    completed --> [*]
+    failed --> [*]
+    cancelled --> [*]
+```
+
+## API + Worker Sequence
+
+```mermaid
+sequenceDiagram
+    participant UI as Frontend
+    participant API as Flask API
+    participant DB as Postgres
+    participant WK as Worker
+    participant PL as Pipeline
+
+    UI->>API: POST /api/generate
+    API->>DB: INSERT generation_jobs(status=queued)
+    API-->>UI: { status: success, jobId }
+
+    loop Polling
+      UI->>API: GET /api/jobs/:id
+      API->>DB: SELECT job
+      API-->>UI: job state
+      UI->>API: GET /api/jobs/:id/events?after=n
+      API->>DB: SELECT events > n
+      API-->>UI: event list
+    end
+
+    WK->>DB: claim queued job
+    WK->>DB: UPDATE status=running + INSERT event
+    WK->>PL: run generation pipeline
+    PL-->>WK: result path OR error
+    WK->>DB: UPDATE status + INSERT terminal event
+
+    UI->>API: POST /api/jobs/:id/cancel
+    API->>DB: set cancel_requested=true
+    WK->>DB: observes cancel and marks cancelled
+```
+
+## Data Model (Current Core)
+
+```mermaid
+erDiagram
+    projects ||--o{ generation_jobs : contains
+    generation_jobs ||--o{ generation_events : has
+    generation_jobs ||--o{ scripts : produces
+    generation_jobs ||--o{ artifacts : produces
+
+    projects {
+      int id PK
+      string name
+      datetime created_at
+    }
+
+    generation_jobs {
+      string id PK
+      int project_id FK
+      string status
+      json payload
+      boolean cancel_requested
+      int attempt_count
+      int max_attempts
+      string result_path
+      text error_message
+      datetime created_at
+      datetime started_at
+      datetime completed_at
+      datetime updated_at
+    }
+
+    generation_events {
+      int id PK
+      string job_id FK
+      string event_type
+      string level
+      text message
+      json payload
+      datetime created_at
+    }
+
+    scripts {
+      int id PK
+      string job_id FK
+      string model_name
+      text content
+      datetime created_at
+    }
+
+    artifacts {
+      int id PK
+      string job_id FK
+      string artifact_type
+      string path
+      json metadata_json
+      datetime created_at
+    }
+```
+
+## Current Guarantees
+
+- API is fast and non-blocking for generation requests.
+- Job state and logs survive API/worker restarts.
+- Cancellation is job-scoped (`cancel_requested`) and checked during processing.
+- Frontend can recover progress after refresh by polling persisted events.
+
+## Planned Next Hardening
+
+- Add migration tool (Alembic) for schema versioning.
+- Add retries/backoff with `next_retry_at` and dead-letter semantics.
+- Add artifact metadata population and checksum tracking.
+- Add worker concurrency controls and queue metrics endpoints.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,6 +19,10 @@ Use `.env.example` as your template.
 | `OLLAMA_BASE_URL` | Ollama server base URL used for model listing and chat generation. | `http://localhost:11434` |
 | `OLLAMA_MODEL` | Fallback model if frontend does not send a model value. | `llama3.1:8b` |
 | `ASSEMBLY_AI_API_KEY` | If set, subtitles are generated with AssemblyAI; otherwise local subtitle generation is used. | empty |
+| `POSTGRES_DB` | Database name for Docker Postgres service. | `moneyprinter` |
+| `POSTGRES_USER` | Database user for Docker Postgres service. | `moneyprinter` |
+| `POSTGRES_PASSWORD` | Database password for Docker Postgres service. | `moneyprinter` |
+| `DATABASE_URL` | SQLAlchemy DSN used by API and worker (`postgresql+psycopg://...` or `sqlite:///...`). | `sqlite:///moneyprinter.db` |
 
 ## Notes
 
@@ -30,3 +34,4 @@ ollama pull llama3.1:8b
 ```
 
 - If ImageMagick is not discovered automatically, set `IMAGEMAGICK_BINARY` explicitly.
+- New architecture uses a database-backed job queue. In Docker, use Postgres via `DATABASE_URL`.

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,6 +1,6 @@
 # Docker
 
-Run MoneyPrinter frontend and backend with Docker Compose.
+Run MoneyPrinter frontend, API, worker, and Postgres with Docker Compose.
 
 ## 1) Prepare environment
 
@@ -12,6 +12,13 @@ Set required keys in `.env`:
 
 - `TIKTOK_SESSION_ID`
 - `PEXELS_API_KEY`
+
+Database defaults (already in `.env.example`):
+
+- `POSTGRES_DB=moneyprinter`
+- `POSTGRES_USER=moneyprinter`
+- `POSTGRES_PASSWORD=moneyprinter`
+- `DATABASE_URL=postgresql+psycopg://moneyprinter:moneyprinter@postgres:5432/moneyprinter`
 
 ## 2) Ollama connectivity
 
@@ -33,6 +40,7 @@ docker compose up --build
 
 - Frontend: `http://localhost:8001`
 - Backend API: `http://localhost:8080`
+- Postgres: `localhost:5432`
 
 ## 5) Verify model listing
 
@@ -41,3 +49,18 @@ curl http://localhost:8080/api/models
 ```
 
 You should receive a JSON payload with `models` and `default`.
+
+## 6) Queue a generation job
+
+```bash
+curl -X POST http://localhost:8080/api/generate \
+  -H "Content-Type: application/json" \
+  -d '{"videoSubject":"AI business ideas","aiModel":"llama3.1:8b","voice":"en_us_001","paragraphNumber":1,"customPrompt":""}'
+```
+
+Response includes `jobId`. Query status and events:
+
+```bash
+curl http://localhost:8080/api/jobs/<jobId>
+curl "http://localhost:8080/api/jobs/<jobId>/events?after=0"
+```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,7 +2,28 @@
 
 Run MoneyPrinter locally with an Ollama model.
 
-## 1) Prerequisites
+## 1) Clone repository
+
+```bash
+git clone https://github.com/FujiwaraChoki/MoneyPrinter.git
+cd MoneyPrinter
+```
+
+## 2) Quick setup (recommended)
+
+Run the interactive setup script:
+
+```bash
+./setup.sh
+```
+
+This script checks dependencies, sets up `.env`, installs Python packages with `uv`, and can optionally pull an Ollama model.
+
+## 3) Manual setup
+
+Use this path if you prefer to run each step yourself.
+
+### Prerequisites
 
 - Python 3.11+
 - [uv](https://docs.astral.sh/uv/getting-started/installation/)
@@ -10,11 +31,9 @@ Run MoneyPrinter locally with an Ollama model.
 - ImageMagick
 - Ollama
 
-## 2) Clone and install
+### Install and create env file
 
 ```bash
-git clone https://github.com/FujiwaraChoki/MoneyPrinter.git
-cd MoneyPrinter
 uv sync
 cp .env.example .env
 ```
@@ -25,7 +44,7 @@ Windows PowerShell for `.env` copy:
 Copy-Item .env.example .env
 ```
 
-## 3) Configure environment
+## 4) Configure environment
 
 Set required values in `.env`:
 
@@ -34,7 +53,14 @@ Set required values in `.env`:
 
 See [Configuration](configuration.md) for all variables.
 
-## 4) Start Ollama and pull a model
+## Optional: Run tests
+
+```bash
+uv sync --group dev
+uv run pytest
+```
+
+## 5) Start Ollama and pull a model
 
 ```bash
 ollama serve
@@ -43,13 +69,21 @@ ollama pull llama3.1:8b
 
 If Ollama runs on another machine/port, set `OLLAMA_BASE_URL` in `.env`.
 
-## 5) Run backend
+## 6) Run backend
 
 ```bash
 uv run python Backend/main.py
 ```
 
-## 6) Run frontend
+## 7) Run worker
+
+In a new terminal:
+
+```bash
+uv run python Backend/worker.py
+```
+
+## 8) Run frontend
 
 In a new terminal:
 
@@ -60,7 +94,7 @@ python3 -m http.server 3000
 
 Open `http://localhost:3000`.
 
-## 7) Generate video
+## 9) Generate video
 
 1. Enter a video subject.
 2. Expand advanced options.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,40 @@
+# Testing
+
+MoneyPrinter uses `pytest` for backend tests.
+
+## Install test dependencies
+
+Install dev dependencies (includes `pytest`):
+
+```bash
+uv sync --group dev
+```
+
+## Run tests
+
+Run all tests:
+
+```bash
+uv run pytest
+```
+
+Run one test file:
+
+```bash
+uv run pytest tests/test_repository.py
+```
+
+Run one test:
+
+```bash
+uv run pytest tests/test_repository.py::test_create_job_persists_payload_and_queued_event
+```
+
+## Current test scope
+
+- `tests/test_api_jobs.py`: API queue, job status/events, and cancellation endpoints.
+- `tests/test_api_misc.py`: API model listing fallback and song upload endpoint behavior.
+- `tests/test_repository.py`: queue/repository behavior for create, claim, cancel, and completion events.
+- `tests/test_worker.py`: worker loop behavior for success, cancellation, failure, and empty queue.
+- `tests/test_utils.py`: filesystem cleanup, song selection, and ImageMagick binary resolution.
+- `tests/conftest.py`: isolated SQLite session fixture per test.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,4 +22,15 @@ dependencies = [
     "brotli",
     "google-api-python-client",
     "oauth2client",
+    "sqlalchemy==2.0.36",
+    "psycopg[binary]==3.2.3",
 ]
+
+[dependency-groups]
+dev = [
+    "pytest==8.4.1",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"

--- a/setup.sh
+++ b/setup.sh
@@ -156,6 +156,58 @@ check_prereqs() {
   return 0
 }
 
+configure_local_database_url() {
+  if [ ! -f .env ]; then
+    return 0
+  fi
+
+  db_result="$(python3 - <<'PY'
+from pathlib import Path
+
+env_path = Path('.env')
+text = env_path.read_text(encoding='utf-8')
+has_trailing_newline = text.endswith('\n')
+lines = text.splitlines()
+target = 'DATABASE_URL="sqlite:///moneyprinter.db"'
+
+for index, line in enumerate(lines):
+    if not line.startswith('DATABASE_URL='):
+        continue
+
+    value = line.split('=', 1)[1].strip().strip('"').strip("'")
+    if value == '' or value.startswith('postgresql+psycopg://'):
+        lines[index] = target
+        env_path.write_text(
+            '\n'.join(lines) + ('\n' if has_trailing_newline else ''),
+            encoding='utf-8',
+        )
+        print('updated')
+    else:
+        print('kept')
+    break
+else:
+    lines.append(target)
+    env_path.write_text(
+        '\n'.join(lines) + ('\n' if has_trailing_newline or lines else ''),
+        encoding='utf-8',
+    )
+    print('added')
+PY
+)"
+
+  case "$db_result" in
+    updated)
+      info 'Set DATABASE_URL to local SQLite default in .env'
+      ;;
+    added)
+      info 'Added DATABASE_URL local SQLite default to .env'
+      ;;
+    *)
+      info 'Keeping existing DATABASE_URL in .env'
+      ;;
+  esac
+}
+
 setup_env_file() {
   if [ ! -f .env.example ]; then
     warn '.env.example is missing; skipping env setup.'
@@ -173,6 +225,8 @@ setup_env_file() {
     cp .env.example .env
     ok 'Created .env from .env.example'
   fi
+
+  configure_local_database_url
 
   if ask_yes_no 'Open .env now to edit required keys?' 'y'; then
     if [ -n "${EDITOR:-}" ] && command_exists "$EDITOR"; then
@@ -237,8 +291,9 @@ check_ollama_models() {
 print_next_steps() {
   printf '\n%sNext steps%s\n' "$BOLD" "$RESET"
   printf '%s1.%s Start backend: %suv run python Backend/main.py%s\n' "$CYAN" "$RESET" "$BOLD" "$RESET"
-  printf '%s2.%s Start frontend (new terminal): %spython3 -m http.server 3000 --directory Frontend%s\n' "$CYAN" "$RESET" "$BOLD" "$RESET"
-  printf '%s3.%s Open: %shttp://localhost:3000%s\n\n' "$CYAN" "$RESET" "$BOLD" "$RESET"
+  printf '%s2.%s Start worker (new terminal): %suv run python Backend/worker.py%s\n' "$CYAN" "$RESET" "$BOLD" "$RESET"
+  printf '%s3.%s Start frontend (new terminal): %spython3 -m http.server 3000 --directory Frontend%s\n' "$CYAN" "$RESET" "$BOLD" "$RESET"
+  printf '%s4.%s Open: %shttp://localhost:3000%s\n\n' "$CYAN" "$RESET" "$BOLD" "$RESET"
 }
 
 main() {

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+
+set -u
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$SCRIPT_DIR"
+
+if ! cd "$PROJECT_ROOT"; then
+  printf 'Failed to enter project directory: %s\n' "$PROJECT_ROOT"
+  exit 1
+fi
+
+if [ -t 1 ] && command -v tput >/dev/null 2>&1; then
+  COLOR_COUNT="$(tput colors 2>/dev/null || printf '0')"
+else
+  COLOR_COUNT="0"
+fi
+
+if [ "$COLOR_COUNT" -ge 8 ]; then
+  BOLD="$(tput bold)"
+  RESET="$(tput sgr0)"
+  RED="$(tput setaf 1)"
+  GREEN="$(tput setaf 2)"
+  YELLOW="$(tput setaf 3)"
+  BLUE="$(tput setaf 4)"
+  MAGENTA="$(tput setaf 5)"
+  CYAN="$(tput setaf 6)"
+else
+  BOLD=''
+  RESET=''
+  RED=''
+  GREEN=''
+  YELLOW=''
+  BLUE=''
+  MAGENTA=''
+  CYAN=''
+fi
+
+print_banner() {
+  printf '\n'
+  printf '%s%sMoneyPrinter Interactive Setup%s\n' "$BOLD" "$MAGENTA" "$RESET"
+  printf '%s--------------------------------%s\n' "$MAGENTA" "$RESET"
+  printf '%sThis script helps you prepare your local environment.%s\n\n' "$CYAN" "$RESET"
+}
+
+info() {
+  printf '%s[INFO]%s %s\n' "$BLUE" "$RESET" "$1"
+}
+
+ok() {
+  printf '%s[OK]%s   %s\n' "$GREEN" "$RESET" "$1"
+}
+
+warn() {
+  printf '%s[WARN]%s %s\n' "$YELLOW" "$RESET" "$1"
+}
+
+error() {
+  printf '%s[ERR]%s  %s\n' "$RED" "$RESET" "$1"
+}
+
+command_exists() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+ask_yes_no() {
+  prompt="$1"
+  default="$2"
+
+  while true; do
+    if [ "$default" = "y" ]; then
+      printf '%s [Y/n]: ' "$prompt"
+    else
+      printf '%s [y/N]: ' "$prompt"
+    fi
+
+    read -r reply
+    case "$reply" in
+      [Yy]|[Yy][Ee][Ss])
+        return 0
+        ;;
+      [Nn]|[Nn][Oo])
+        return 1
+        ;;
+      '')
+        if [ "$default" = "y" ]; then
+          return 0
+        fi
+        return 1
+        ;;
+      *)
+        warn 'Please answer y or n.'
+        ;;
+    esac
+  done
+}
+
+check_python_version() {
+  if ! command_exists python3; then
+    error 'python3 not found (required: 3.11+).'
+    return 1
+  fi
+
+  PYTHON_VERSION="$(python3 -c 'import sys; print(".".join(map(str, sys.version_info[:3])))' 2>/dev/null || printf '0.0.0')"
+  MAJOR="$(printf '%s' "$PYTHON_VERSION" | cut -d. -f1)"
+  MINOR="$(printf '%s' "$PYTHON_VERSION" | cut -d. -f2)"
+
+  if [ "$MAJOR" -gt 3 ] || { [ "$MAJOR" -eq 3 ] && [ "$MINOR" -ge 11 ]; }; then
+    ok "python3 found ($PYTHON_VERSION)"
+    return 0
+  fi
+
+  error "python3 version is $PYTHON_VERSION (need 3.11+)"
+  return 1
+}
+
+check_prereqs() {
+  info 'Checking prerequisites...'
+
+  missing_critical=0
+
+  if ! check_python_version; then
+    missing_critical=1
+  fi
+
+  if command_exists uv; then
+    ok 'uv found'
+  else
+    error 'uv not found (install: https://docs.astral.sh/uv/getting-started/installation/)'
+    missing_critical=1
+  fi
+
+  if command_exists ffmpeg; then
+    ok 'ffmpeg found'
+  else
+    warn 'ffmpeg not found (required for video generation).'
+  fi
+
+  if command_exists magick || command_exists convert; then
+    ok 'ImageMagick found'
+  else
+    warn 'ImageMagick not found (some text rendering features may fail).'
+  fi
+
+  if command_exists ollama; then
+    ok 'ollama found'
+  else
+    warn 'ollama not found (required for script generation).'
+  fi
+
+  if [ "$missing_critical" -eq 1 ]; then
+    error 'Missing critical dependencies. Please install them, then rerun setup.'
+    return 1
+  fi
+
+  return 0
+}
+
+setup_env_file() {
+  if [ ! -f .env.example ]; then
+    warn '.env.example is missing; skipping env setup.'
+    return 0
+  fi
+
+  if [ -f .env ]; then
+    if ask_yes_no '.env already exists. Overwrite it from .env.example?' 'n'; then
+      cp .env.example .env
+      ok '.env overwritten from .env.example'
+    else
+      info 'Keeping existing .env'
+    fi
+  else
+    cp .env.example .env
+    ok 'Created .env from .env.example'
+  fi
+
+  if ask_yes_no 'Open .env now to edit required keys?' 'y'; then
+    if [ -n "${EDITOR:-}" ] && command_exists "$EDITOR"; then
+      "$EDITOR" .env
+    elif command_exists nano; then
+      nano .env
+    elif command_exists vi; then
+      vi .env
+    else
+      warn "No terminal editor detected. Please edit $PROJECT_ROOT/.env manually."
+    fi
+  fi
+}
+
+install_dependencies() {
+  if ask_yes_no 'Install Python dependencies with uv sync?' 'y'; then
+    info 'Running uv sync...'
+    if uv sync; then
+      ok 'Dependencies installed'
+    else
+      error 'uv sync failed'
+      return 1
+    fi
+  else
+    warn 'Skipped dependency installation.'
+  fi
+
+  return 0
+}
+
+check_ollama_models() {
+  if ! command_exists ollama; then
+    return 0
+  fi
+
+  if ! ask_yes_no 'Check local Ollama models now?' 'y'; then
+    return 0
+  fi
+
+  info 'Querying Ollama model list...'
+  if ollama list; then
+    ok 'Ollama is reachable.'
+  else
+    warn 'Could not query Ollama. If needed, run: ollama serve'
+    return 0
+  fi
+
+  if ask_yes_no 'Pull default model llama3.1:8b now?' 'n'; then
+    printf 'Model name [llama3.1:8b]: '
+    read -r model_name
+    model_name="${model_name:-llama3.1:8b}"
+
+    info "Pulling model $model_name ..."
+    if ollama pull "$model_name"; then
+      ok "Model $model_name is ready"
+    else
+      warn "Failed to pull model $model_name"
+    fi
+  fi
+}
+
+print_next_steps() {
+  printf '\n%sNext steps%s\n' "$BOLD" "$RESET"
+  printf '%s1.%s Start backend: %suv run python Backend/main.py%s\n' "$CYAN" "$RESET" "$BOLD" "$RESET"
+  printf '%s2.%s Start frontend (new terminal): %spython3 -m http.server 3000 --directory Frontend%s\n' "$CYAN" "$RESET" "$BOLD" "$RESET"
+  printf '%s3.%s Open: %shttp://localhost:3000%s\n\n' "$CYAN" "$RESET" "$BOLD" "$RESET"
+}
+
+main() {
+  print_banner
+
+  if ! check_prereqs; then
+    exit 1
+  fi
+
+  setup_env_file
+
+  if ! install_dependencies; then
+    exit 1
+  fi
+
+  check_ollama_models
+  print_next_steps
+  ok 'Setup complete. Happy building!'
+}
+
+main "$@"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,42 @@
+import sys
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+BACKEND_DIR = PROJECT_ROOT / "Backend"
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+from db import Base  # noqa: E402
+import models  # noqa: F401,E402
+
+
+@pytest.fixture
+def session_factory(tmp_path: Path):
+    database_file = tmp_path / "test.db"
+    engine = create_engine(
+        f"sqlite:///{database_file}",
+        connect_args={"check_same_thread": False},
+    )
+    session_factory = sessionmaker(
+        bind=engine,
+        autoflush=False,
+        autocommit=False,
+        expire_on_commit=False,
+    )
+    Base.metadata.create_all(bind=engine)
+
+    yield session_factory
+
+    Base.metadata.drop_all(bind=engine)
+    engine.dispose()
+
+
+@pytest.fixture
+def session(session_factory):
+    with session_factory() as db_session:
+        yield db_session

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from pathlib import Path
 
@@ -10,6 +11,8 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 BACKEND_DIR = PROJECT_ROOT / "Backend"
 if str(BACKEND_DIR) not in sys.path:
     sys.path.insert(0, str(BACKEND_DIR))
+
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
 
 from db import Base  # noqa: E402
 import models  # noqa: F401,E402

--- a/tests/test_api_jobs.py
+++ b/tests/test_api_jobs.py
@@ -1,0 +1,129 @@
+import os
+
+import pytest
+
+from repository import append_event, create_job, get_job, list_job_events
+
+
+os.environ.setdefault("PEXELS_API_KEY", "test-key")
+os.environ.setdefault("TIKTOK_SESSION_ID", "test-session")
+os.environ.setdefault("IMAGEMAGICK_BINARY", "/bin/echo")
+os.environ.setdefault("DATABASE_URL", "sqlite:///moneyprinter_api_bootstrap.db")
+
+import main
+
+
+@pytest.fixture
+def client(monkeypatch, session_factory):
+    monkeypatch.setattr(main, "SessionLocal", session_factory)
+    return main.app.test_client()
+
+
+def test_generate_requires_video_subject(client):
+    response = client.post("/api/generate", json={})
+
+    assert response.status_code == 400
+    payload = response.get_json()
+    assert payload["status"] == "error"
+    assert payload["message"] == "videoSubject is required."
+
+
+def test_generate_creates_job_and_job_status_is_fetchable(client):
+    response = client.post(
+        "/api/generate",
+        json={
+            "videoSubject": "api queue test",
+            "paragraphNumber": 1,
+            "customPrompt": "",
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["status"] == "success"
+    assert payload["message"] == "Video generation queued."
+
+    job_id = payload["jobId"]
+    job_response = client.get(f"/api/jobs/{job_id}")
+    job_payload = job_response.get_json()
+
+    assert job_response.status_code == 200
+    assert job_payload["status"] == "success"
+    assert job_payload["job"]["id"] == job_id
+    assert job_payload["job"]["state"] == "queued"
+
+
+def test_get_events_respects_after_query_parameter(client, session_factory):
+    with session_factory() as session:
+        job = create_job(session, payload={"videoSubject": "events"})
+        first_event = list_job_events(session, job.id)[0]
+        append_event(session, job.id, "log", "info", "step 2")
+        append_event(session, job.id, "log", "info", "step 3")
+        session.commit()
+
+    response = client.get(f"/api/jobs/{job.id}/events?after={first_event.id}")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["status"] == "success"
+    assert len(payload["events"]) == 2
+    assert payload["events"][0]["message"] == "step 2"
+    assert payload["events"][1]["message"] == "step 3"
+
+
+def test_cancel_job_endpoint_cancels_existing_job(client, session_factory):
+    with session_factory() as session:
+        job = create_job(session, payload={"videoSubject": "cancel endpoint"})
+
+    response = client.post(f"/api/jobs/{job.id}/cancel")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["status"] == "success"
+    assert payload["message"] == "Cancellation requested."
+
+    with session_factory() as session:
+        updated_job = get_job(session, job.id)
+        assert updated_job is not None
+        assert updated_job.status == "cancelled"
+        assert updated_job.cancel_requested is True
+
+
+def test_cancel_job_endpoint_returns_404_for_unknown_job(client):
+    response = client.post("/api/jobs/missing-id/cancel")
+
+    assert response.status_code == 404
+    payload = response.get_json()
+    assert payload["status"] == "error"
+    assert payload["message"] == "Job not found."
+
+
+def test_cancel_latest_running_job_returns_404_when_no_active_job(client):
+    response = client.post("/api/cancel")
+
+    assert response.status_code == 404
+    payload = response.get_json()
+    assert payload["status"] == "error"
+    assert payload["message"] == "No active job found."
+
+
+def test_cancel_latest_running_job_cancels_active_job(client, session_factory):
+    with session_factory() as session:
+        older_job = create_job(session, payload={"videoSubject": "older"})
+        newer_job = create_job(session, payload={"videoSubject": "newer"})
+
+    response = client.post("/api/cancel")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["status"] == "success"
+    assert payload["message"] == "Cancellation requested."
+    assert payload["jobId"] in {older_job.id, newer_job.id}
+
+    with session_factory() as session:
+        older = get_job(session, older_job.id)
+        newer = get_job(session, newer_job.id)
+        assert older is not None
+        assert newer is not None
+        cancelled_count = int(older.cancel_requested) + int(newer.cancel_requested)
+        assert cancelled_count == 1

--- a/tests/test_api_misc.py
+++ b/tests/test_api_misc.py
@@ -1,0 +1,121 @@
+import io
+import os
+
+import pytest
+
+
+os.environ.setdefault("PEXELS_API_KEY", "test-key")
+os.environ.setdefault("TIKTOK_SESSION_ID", "test-session")
+os.environ.setdefault("IMAGEMAGICK_BINARY", "/bin/echo")
+os.environ.setdefault("DATABASE_URL", "sqlite:///moneyprinter_api_misc_bootstrap.db")
+
+import main
+
+
+@pytest.fixture
+def client():
+    return main.app.test_client()
+
+
+def test_models_endpoint_success_response(client, monkeypatch):
+    def fake_list_models():
+        return ["llama3.1:8b", "qwen3:8b"], "qwen3:8b"
+
+    monkeypatch.setattr(main, "list_ollama_models", fake_list_models)
+
+    response = client.get("/api/models")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["status"] == "success"
+    assert payload["models"] == ["llama3.1:8b", "qwen3:8b"]
+    assert payload["default"] == "qwen3:8b"
+
+
+def test_models_endpoint_fallback_on_error(client, monkeypatch):
+    monkeypatch.setenv("OLLAMA_MODEL", "custom:model")
+
+    def fake_list_models():
+        raise RuntimeError("ollama unavailable")
+
+    monkeypatch.setattr(main, "list_ollama_models", fake_list_models)
+
+    response = client.get("/api/models")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["status"] == "error"
+    assert payload["message"] == "Could not fetch Ollama models. Is Ollama running?"
+    assert payload["models"] == ["custom:model"]
+    assert payload["default"] == "custom:model"
+
+
+def test_upload_songs_requires_files(client):
+    response = client.post(
+        "/api/upload-songs", data={}, content_type="multipart/form-data"
+    )
+
+    assert response.status_code == 400
+    payload = response.get_json()
+    assert payload["status"] == "error"
+    assert payload["message"] == "No files uploaded."
+
+
+def test_upload_songs_rejects_non_mp3_files(client, monkeypatch, tmp_path):
+    songs_dir = tmp_path / "Songs"
+    songs_dir.mkdir()
+
+    monkeypatch.setattr(main, "SONGS_DIR", songs_dir)
+    monkeypatch.setattr(main, "clean_dir", lambda path: None)
+
+    data = {
+        "songs": (io.BytesIO(b"not-mp3"), "track.wav"),
+    }
+    response = client.post(
+        "/api/upload-songs",
+        data=data,
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 400
+    payload = response.get_json()
+    assert payload["status"] == "error"
+    assert payload["message"] == "No MP3 files found."
+    assert list(songs_dir.iterdir()) == []
+
+
+def test_upload_songs_saves_mp3_and_sanitizes_filename(client, monkeypatch, tmp_path):
+    songs_dir = tmp_path / "Songs"
+    songs_dir.mkdir()
+    stale_file = songs_dir / "stale.mp3"
+    stale_file.write_bytes(b"old")
+
+    def fake_clean_dir(path: str):
+        assert path == str(songs_dir)
+        for item in songs_dir.iterdir():
+            if item.is_file():
+                item.unlink()
+
+    monkeypatch.setattr(main, "SONGS_DIR", songs_dir)
+    monkeypatch.setattr(main, "clean_dir", fake_clean_dir)
+
+    data = {
+        "songs": [
+            (io.BytesIO(b"song-a"), "../danger.mp3"),
+            (io.BytesIO(b"song-b"), "safe.mp3"),
+            (io.BytesIO(b"ignore"), "note.txt"),
+        ]
+    }
+    response = client.post(
+        "/api/upload-songs",
+        data=data,
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["status"] == "success"
+    assert payload["message"] == "Uploaded 2 song(s)."
+
+    saved_names = sorted(path.name for path in songs_dir.iterdir())
+    assert saved_names == ["danger.mp3", "safe.mp3"]

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1,0 +1,83 @@
+from repository import (
+    claim_next_queued_job,
+    create_job,
+    list_job_events,
+    mark_failed,
+    mark_completed,
+    mark_cancelled,
+    request_cancel,
+)
+
+
+def test_create_job_persists_payload_and_queued_event(session):
+    payload = {"videoSubject": "money basics", "paragraphNumber": 1}
+
+    job = create_job(session, payload=payload)
+
+    assert job.id
+    assert job.status == "queued"
+    assert job.payload == payload
+
+    events = list_job_events(session, job.id)
+    assert len(events) == 1
+    assert events[0].event_type == "queued"
+    assert events[0].message == "Job queued."
+
+
+def test_request_cancel_cancels_queued_job_and_tracks_events(session):
+    job = create_job(session, payload={"videoSubject": "cancel me"})
+
+    cancelled = request_cancel(session, job.id)
+
+    assert cancelled is True
+
+    events = list_job_events(session, job.id)
+    event_types = [event.event_type for event in events]
+    assert "cancel_requested" in event_types
+    assert "cancelled" in event_types
+
+
+def test_claim_next_queued_job_marks_running_and_skips_cancelled(session):
+    first_job = create_job(session, payload={"videoSubject": "first"})
+    second_job = create_job(session, payload={"videoSubject": "second"})
+    request_cancel(session, first_job.id)
+
+    claimed_job = claim_next_queued_job(session)
+
+    assert claimed_job is not None
+    assert claimed_job.id == second_job.id
+    assert claimed_job.status == "running"
+    assert claimed_job.attempt_count == 1
+
+
+def test_mark_completed_updates_status_and_emits_complete_event(session):
+    job = create_job(session, payload={"videoSubject": "done"})
+    running_job = claim_next_queued_job(session)
+    assert running_job is not None
+
+    mark_completed(session, job.id, result_path="/tmp/output.mp4")
+
+    events = list_job_events(session, job.id)
+    complete_events = [event for event in events if event.event_type == "complete"]
+    assert len(complete_events) == 1
+    assert complete_events[0].payload == {"path": "/tmp/output.mp4"}
+
+
+def test_mark_failed_updates_error_message_and_event(session):
+    job = create_job(session, payload={"videoSubject": "bad run"})
+
+    mark_failed(session, job.id, error_message="render crash")
+
+    events = list_job_events(session, job.id)
+    assert events[-1].event_type == "error"
+    assert events[-1].message == "render crash"
+
+
+def test_mark_cancelled_sets_status_and_writes_cancelled_event(session):
+    job = create_job(session, payload={"videoSubject": "stop"})
+
+    mark_cancelled(session, job.id, reason="cancelled in worker")
+
+    events = list_job_events(session, job.id)
+    assert events[-1].event_type == "cancelled"
+    assert events[-1].message == "cancelled in worker"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+
+import utils
+
+
+def test_clean_dir_removes_existing_files_and_directories(tmp_path: Path):
+    target_dir = tmp_path / "cleanup"
+    nested_dir = target_dir / "nested"
+    nested_dir.mkdir(parents=True)
+    (target_dir / "root.txt").write_text("root")
+    (nested_dir / "nested.txt").write_text("nested")
+
+    utils.clean_dir(str(target_dir))
+
+    assert target_dir.exists()
+    assert list(target_dir.iterdir()) == []
+
+
+def test_choose_random_song_returns_none_if_songs_dir_missing(
+    monkeypatch, tmp_path: Path
+):
+    songs_dir = tmp_path / "Songs"
+    monkeypatch.setattr(utils, "SONGS_DIR", songs_dir)
+
+    assert utils.choose_random_song() is None
+
+
+def test_choose_random_song_returns_selected_mp3(monkeypatch, tmp_path: Path):
+    songs_dir = tmp_path / "Songs"
+    songs_dir.mkdir()
+    first_song = songs_dir / "a.mp3"
+    second_song = songs_dir / "b.mp3"
+    ignored_file = songs_dir / "notes.txt"
+    first_song.write_text("a")
+    second_song.write_text("b")
+    ignored_file.write_text("ignore")
+
+    monkeypatch.setattr(utils, "SONGS_DIR", songs_dir)
+    monkeypatch.setattr(utils.random, "choice", lambda songs: songs[0])
+
+    selected = utils.choose_random_song()
+
+    assert selected == str(first_song)
+
+
+def test_resolve_imagemagick_binary_prefers_configured_existing_path(
+    monkeypatch, tmp_path: Path
+):
+    fake_binary = tmp_path / "magick"
+    fake_binary.write_text("binary")
+    monkeypatch.setenv("IMAGEMAGICK_BINARY", str(fake_binary))
+
+    resolved = utils.resolve_imagemagick_binary()
+
+    assert resolved == str(fake_binary.resolve())
+
+
+def test_resolve_imagemagick_binary_falls_back_to_path_lookup(monkeypatch):
+    monkeypatch.setenv("IMAGEMAGICK_BINARY", "")
+
+    def fake_which(candidate: str):
+        if candidate == "magick":
+            return "/usr/local/bin/magick"
+        return None
+
+    monkeypatch.setattr(utils.shutil, "which", fake_which)
+
+    resolved = utils.resolve_imagemagick_binary()
+
+    assert resolved == "/usr/local/bin/magick"

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,0 +1,137 @@
+from repository import create_job, get_job, list_job_events
+import worker
+
+
+def _disable_cleanup(monkeypatch):
+    monkeypatch.setattr(worker, "clean_dir", lambda _: None)
+
+
+def test_process_next_job_returns_false_when_queue_is_empty(
+    monkeypatch, session_factory
+):
+    monkeypatch.setattr(worker, "SessionLocal", session_factory)
+    _disable_cleanup(monkeypatch)
+
+    assert worker.process_next_job() is False
+
+
+def test_process_next_job_marks_completed_on_pipeline_success(
+    monkeypatch, session_factory
+):
+    with session_factory() as session:
+        job = create_job(session, payload={"videoSubject": "worker success"})
+
+    monkeypatch.setattr(worker, "SessionLocal", session_factory)
+    _disable_cleanup(monkeypatch)
+
+    def fake_pipeline(data, is_cancelled, on_log):
+        assert data["videoSubject"] == "worker success"
+        assert is_cancelled() is False
+        on_log("pipeline started", "info")
+        return "rendered.mp4"
+
+    monkeypatch.setattr(worker, "run_generation_pipeline", fake_pipeline)
+
+    assert worker.process_next_job() is True
+
+    with session_factory() as session:
+        updated_job = get_job(session, job.id)
+        assert updated_job is not None
+        assert updated_job.status == "completed"
+        assert updated_job.result_path == "rendered.mp4"
+
+        event_types = [event.event_type for event in list_job_events(session, job.id)]
+        assert "running" in event_types
+        assert "log" in event_types
+        assert "complete" in event_types
+
+
+def test_process_next_job_marks_cancelled_on_pipeline_cancelled(
+    monkeypatch, session_factory
+):
+    with session_factory() as session:
+        job = create_job(session, payload={"videoSubject": "worker cancelled"})
+
+    monkeypatch.setattr(worker, "SessionLocal", session_factory)
+    _disable_cleanup(monkeypatch)
+
+    def fake_pipeline(*_args, **_kwargs):
+        raise worker.PipelineCancelled("cancelled by user")
+
+    monkeypatch.setattr(worker, "run_generation_pipeline", fake_pipeline)
+
+    assert worker.process_next_job() is True
+
+    with session_factory() as session:
+        updated_job = get_job(session, job.id)
+        assert updated_job is not None
+        assert updated_job.status == "cancelled"
+
+        events = list_job_events(session, job.id)
+        assert events[-1].event_type == "cancelled"
+        assert events[-1].message == "cancelled by user"
+
+
+def test_process_next_job_marks_failed_on_pipeline_error(monkeypatch, session_factory):
+    with session_factory() as session:
+        job = create_job(session, payload={"videoSubject": "worker failure"})
+
+    monkeypatch.setattr(worker, "SessionLocal", session_factory)
+    _disable_cleanup(monkeypatch)
+
+    def fake_pipeline(*_args, **_kwargs):
+        raise RuntimeError("pipeline exploded")
+
+    monkeypatch.setattr(worker, "run_generation_pipeline", fake_pipeline)
+
+    assert worker.process_next_job() is True
+
+    with session_factory() as session:
+        updated_job = get_job(session, job.id)
+        assert updated_job is not None
+        assert updated_job.status == "failed"
+        assert updated_job.error_message == "pipeline exploded"
+
+        events = list_job_events(session, job.id)
+        assert events[-1].event_type == "error"
+        assert events[-1].message == "pipeline exploded"
+
+
+def test_job_cancelled_helper_returns_true_for_missing_job(
+    monkeypatch, session_factory
+):
+    monkeypatch.setattr(worker, "SessionLocal", session_factory)
+
+    assert worker._job_cancelled("missing-job-id") is True
+
+
+def test_job_cancelled_helper_reflects_cancel_flag(monkeypatch, session_factory):
+    with session_factory() as session:
+        job = create_job(session, payload={"videoSubject": "cancel-check"})
+
+    monkeypatch.setattr(worker, "SessionLocal", session_factory)
+
+    assert worker._job_cancelled(job.id) is False
+
+    with session_factory() as session:
+        job_to_update = get_job(session, job.id)
+        assert job_to_update is not None
+        job_to_update.cancel_requested = True
+        session.commit()
+
+    assert worker._job_cancelled(job.id) is True
+
+
+def test_log_event_helper_persists_log_event(monkeypatch, session_factory):
+    with session_factory() as session:
+        job = create_job(session, payload={"videoSubject": "log-check"})
+
+    monkeypatch.setattr(worker, "SessionLocal", session_factory)
+
+    worker._log_event(job.id, "hello event", "warning")
+
+    with session_factory() as session:
+        events = list_job_events(session, job.id)
+        assert events[-1].event_type == "log"
+        assert events[-1].level == "warning"
+        assert events[-1].message == "hello event"

--- a/uv.lock
+++ b/uv.lock
@@ -475,6 +475,58 @@ wheels = [
 ]
 
 [[package]]
+name = "greenlet"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/51/1664f6b78fc6ebbd98019a1fd730e83fa78f2db7058f72b1463d3612b8db/greenlet-3.3.2.tar.gz", hash = "sha256:2eaf067fc6d886931c7962e8c6bede15d2f01965560f3359b27c80bde2d151f2", size = 188267, upload-time = "2026-02-20T20:54:15.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/47/16400cb42d18d7a6bb46f0626852c1718612e35dcb0dffa16bbaffdf5dd2/greenlet-3.3.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:c56692189a7d1c7606cb794be0a8381470d95c57ce5be03fb3d0ef57c7853b86", size = 278890, upload-time = "2026-02-20T20:19:39.263Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/90/42762b77a5b6aa96cd8c0e80612663d39211e8ae8a6cd47c7f1249a66262/greenlet-3.3.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ebd458fa8285960f382841da585e02201b53a5ec2bac6b156fc623b5ce4499f", size = 581120, upload-time = "2026-02-20T20:47:30.161Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/6f/f3d64f4fa0a9c7b5c5b3c810ff1df614540d5aa7d519261b53fba55d4df9/greenlet-3.3.2-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a443358b33c4ec7b05b79a7c8b466f5d275025e750298be7340f8fc63dff2a55", size = 594363, upload-time = "2026-02-20T20:55:56.965Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/8b/1430a04657735a3f23116c2e0d5eb10220928846e4537a938a41b350bed6/greenlet-3.3.2-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4375a58e49522698d3e70cc0b801c19433021b5c37686f7ce9c65b0d5c8677d2", size = 605046, upload-time = "2026-02-20T21:02:45.234Z" },
+    { url = "https://files.pythonhosted.org/packages/72/83/3e06a52aca8128bdd4dcd67e932b809e76a96ab8c232a8b025b2850264c5/greenlet-3.3.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e2cd90d413acbf5e77ae41e5d3c9b3ac1d011a756d7284d7f3f2b806bbd6358", size = 594156, upload-time = "2026-02-20T20:20:59.955Z" },
+    { url = "https://files.pythonhosted.org/packages/70/79/0de5e62b873e08fe3cef7dbe84e5c4bc0e8ed0c7ff131bccb8405cd107c8/greenlet-3.3.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:442b6057453c8cb29b4fb36a2ac689382fc71112273726e2423f7f17dc73bf99", size = 1554649, upload-time = "2026-02-20T20:49:32.293Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/00/32d30dee8389dc36d42170a9c66217757289e2afb0de59a3565260f38373/greenlet-3.3.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:45abe8eb6339518180d5a7fa47fa01945414d7cca5ecb745346fc6a87d2750be", size = 1619472, upload-time = "2026-02-20T20:21:07.966Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/3a/efb2cf697fbccdf75b24e2c18025e7dfa54c4f31fab75c51d0fe79942cef/greenlet-3.3.2-cp311-cp311-win_amd64.whl", hash = "sha256:1e692b2dae4cc7077cbb11b47d258533b48c8fde69a33d0d8a82e2fe8d8531d5", size = 230389, upload-time = "2026-02-20T20:17:18.772Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/a1/65bbc059a43a7e2143ec4fc1f9e3f673e04f9c7b371a494a101422ac4fd5/greenlet-3.3.2-cp311-cp311-win_arm64.whl", hash = "sha256:02b0a8682aecd4d3c6c18edf52bc8e51eacdd75c8eac52a790a210b06aa295fd", size = 229645, upload-time = "2026-02-20T20:18:18.695Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/ab/1608e5a7578e62113506740b88066bf09888322a311cff602105e619bd87/greenlet-3.3.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:ac8d61d4343b799d1e526db579833d72f23759c71e07181c2d2944e429eb09cd", size = 280358, upload-time = "2026-02-20T20:17:43.971Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/23/0eae412a4ade4e6623ff7626e38998cb9b11e9ff1ebacaa021e4e108ec15/greenlet-3.3.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ceec72030dae6ac0c8ed7591b96b70410a8be370b6a477b1dbc072856ad02bd", size = 601217, upload-time = "2026-02-20T20:47:31.462Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/16/5b1678a9c07098ecb9ab2dd159fafaf12e963293e61ee8d10ecb55273e5e/greenlet-3.3.2-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a2a5be83a45ce6188c045bcc44b0ee037d6a518978de9a5d97438548b953a1ac", size = 611792, upload-time = "2026-02-20T20:55:58.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/c5/cc09412a29e43406eba18d61c70baa936e299bc27e074e2be3806ed29098/greenlet-3.3.2-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae9e21c84035c490506c17002f5c8ab25f980205c3e61ddb3a2a2a2e6c411fcb", size = 626250, upload-time = "2026-02-20T21:02:46.596Z" },
+    { url = "https://files.pythonhosted.org/packages/50/1f/5155f55bd71cabd03765a4aac9ac446be129895271f73872c36ebd4b04b6/greenlet-3.3.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43e99d1749147ac21dde49b99c9abffcbc1e2d55c67501465ef0930d6e78e070", size = 613875, upload-time = "2026-02-20T20:21:01.102Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/dd/845f249c3fcd69e32df80cdab059b4be8b766ef5830a3d0aa9d6cad55beb/greenlet-3.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4c956a19350e2c37f2c48b336a3afb4bff120b36076d9d7fb68cb44e05d95b79", size = 1571467, upload-time = "2026-02-20T20:49:33.495Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/50/2649fe21fcc2b56659a452868e695634722a6655ba245d9f77f5656010bf/greenlet-3.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c6f8ba97d17a1e7d664151284cb3315fc5f8353e75221ed4324f84eb162b395", size = 1640001, upload-time = "2026-02-20T20:21:09.154Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/cc802e067d02af8b60b6771cea7d57e21ef5e6659912814babb42b864713/greenlet-3.3.2-cp312-cp312-win_amd64.whl", hash = "sha256:34308836d8370bddadb41f5a7ce96879b72e2fdfb4e87729330c6ab52376409f", size = 231081, upload-time = "2026-02-20T20:17:28.121Z" },
+    { url = "https://files.pythonhosted.org/packages/58/2e/fe7f36ff1982d6b10a60d5e0740c759259a7d6d2e1dc41da6d96de32fff6/greenlet-3.3.2-cp312-cp312-win_arm64.whl", hash = "sha256:d3a62fa76a32b462a97198e4c9e99afb9ab375115e74e9a83ce180e7a496f643", size = 230331, upload-time = "2026-02-20T20:17:23.34Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/48/f8b875fa7dea7dd9b33245e37f065af59df6a25af2f9561efa8d822fde51/greenlet-3.3.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4", size = 279120, upload-time = "2026-02-20T20:19:01.9Z" },
+    { url = "https://files.pythonhosted.org/packages/49/8d/9771d03e7a8b1ee456511961e1b97a6d77ae1dea4a34a5b98eee706689d3/greenlet-3.3.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986", size = 603238, upload-time = "2026-02-20T20:47:32.873Z" },
+    { url = "https://files.pythonhosted.org/packages/59/0e/4223c2bbb63cd5c97f28ffb2a8aee71bdfb30b323c35d409450f51b91e3e/greenlet-3.3.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92", size = 614219, upload-time = "2026-02-20T20:55:59.817Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2b/4d012a69759ac9d77210b8bfb128bc621125f5b20fc398bce3940d036b1c/greenlet-3.3.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ccd21bb86944ca9be6d967cf7691e658e43417782bce90b5d2faeda0ff78a7dd", size = 628268, upload-time = "2026-02-20T21:02:48.024Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/34/259b28ea7a2a0c904b11cd36c79b8cef8019b26ee5dbe24e73b469dea347/greenlet-3.3.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab", size = 616774, upload-time = "2026-02-20T20:21:02.454Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/03/996c2d1689d486a6e199cb0f1cf9e4aa940c500e01bdf201299d7d61fa69/greenlet-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a", size = 1571277, upload-time = "2026-02-20T20:49:34.795Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/c4/2570fc07f34a39f2caf0bf9f24b0a1a0a47bc2e8e465b2c2424821389dfc/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b", size = 1640455, upload-time = "2026-02-20T20:21:10.261Z" },
+    { url = "https://files.pythonhosted.org/packages/91/39/5ef5aa23bc545aa0d31e1b9b55822b32c8da93ba657295840b6b34124009/greenlet-3.3.2-cp313-cp313-win_amd64.whl", hash = "sha256:a7945dd0eab63ded0a48e4dcade82939783c172290a7903ebde9e184333ca124", size = 230961, upload-time = "2026-02-20T20:16:58.461Z" },
+    { url = "https://files.pythonhosted.org/packages/62/6b/a89f8456dcb06becff288f563618e9f20deed8dd29beea14f9a168aef64b/greenlet-3.3.2-cp313-cp313-win_arm64.whl", hash = "sha256:394ead29063ee3515b4e775216cb756b2e3b4a7e55ae8fd884f17fa579e6b327", size = 230221, upload-time = "2026-02-20T20:17:37.152Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ae/8bffcbd373b57a5992cd077cbe8858fff39110480a9d50697091faea6f39/greenlet-3.3.2-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:8d1658d7291f9859beed69a776c10822a0a799bc4bfe1bd4272bb60e62507dab", size = 279650, upload-time = "2026-02-20T20:18:00.783Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/c0/45f93f348fa49abf32ac8439938726c480bd96b2a3c6f4d949ec0124b69f/greenlet-3.3.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18cb1b7337bca281915b3c5d5ae19f4e76d35e1df80f4ad3c1a7be91fadf1082", size = 650295, upload-time = "2026-02-20T20:47:34.036Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/de/dd7589b3f2b8372069ab3e4763ea5329940fc7ad9dcd3e272a37516d7c9b/greenlet-3.3.2-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2e47408e8ce1c6f1ceea0dffcdf6ebb85cc09e55c7af407c99f1112016e45e9", size = 662163, upload-time = "2026-02-20T20:56:01.295Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ac/85804f74f1ccea31ba518dcc8ee6f14c79f73fe36fa1beba38930806df09/greenlet-3.3.2-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e3cb43ce200f59483eb82949bf1835a99cf43d7571e900d7c8d5c62cdf25d2f9", size = 675371, upload-time = "2026-02-20T21:02:49.664Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/d8/09bfa816572a4d83bccd6750df1926f79158b1c36c5f73786e26dbe4ee38/greenlet-3.3.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63d10328839d1973e5ba35e98cccbca71b232b14051fd957b6f8b6e8e80d0506", size = 664160, upload-time = "2026-02-20T20:21:04.015Z" },
+    { url = "https://files.pythonhosted.org/packages/48/cf/56832f0c8255d27f6c35d41b5ec91168d74ec721d85f01a12131eec6b93c/greenlet-3.3.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e4ab3cfb02993c8cc248ea73d7dae6cec0253e9afa311c9b37e603ca9fad2ce", size = 1619181, upload-time = "2026-02-20T20:49:36.052Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/23/b90b60a4aabb4cec0796e55f25ffbfb579a907c3898cd2905c8918acaa16/greenlet-3.3.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:94ad81f0fd3c0c0681a018a976e5c2bd2ca2d9d94895f23e7bb1af4e8af4e2d5", size = 1687713, upload-time = "2026-02-20T20:21:11.684Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ca/2101ca3d9223a1dc125140dbc063644dca76df6ff356531eb27bc267b446/greenlet-3.3.2-cp314-cp314-win_amd64.whl", hash = "sha256:8c4dd0f3997cf2512f7601563cc90dfb8957c0cff1e3a1b23991d4ea1776c492", size = 232034, upload-time = "2026-02-20T20:20:08.186Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/4a/ecf894e962a59dea60f04877eea0fd5724618da89f1867b28ee8b91e811f/greenlet-3.3.2-cp314-cp314-win_arm64.whl", hash = "sha256:cd6f9e2bbd46321ba3bbb4c8a15794d32960e3b0ae2cc4d49a1a53d314805d71", size = 231437, upload-time = "2026-02-20T20:18:59.722Z" },
+    { url = "https://files.pythonhosted.org/packages/98/6d/8f2ef704e614bcf58ed43cfb8d87afa1c285e98194ab2cfad351bf04f81e/greenlet-3.3.2-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:e26e72bec7ab387ac80caa7496e0f908ff954f31065b0ffc1f8ecb1338b11b54", size = 286617, upload-time = "2026-02-20T20:19:29.856Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/0d/93894161d307c6ea237a43988f27eba0947b360b99ac5239ad3fe09f0b47/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b466dff7a4ffda6ca975979bab80bdadde979e29fc947ac3be4451428d8b0e4", size = 655189, upload-time = "2026-02-20T20:47:35.742Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/2c/d2d506ebd8abcb57386ec4f7ba20f4030cbe56eae541bc6fd6ef399c0b41/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b8bddc5b73c9720bea487b3bffdb1840fe4e3656fba3bd40aa1489e9f37877ff", size = 658225, upload-time = "2026-02-20T20:56:02.527Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/67/8197b7e7e602150938049d8e7f30de1660cfb87e4c8ee349b42b67bdb2e1/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:59b3e2c40f6706b05a9cd299c836c6aa2378cabe25d021acd80f13abf81181cf", size = 666581, upload-time = "2026-02-20T21:02:51.526Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/30/3a09155fbf728673a1dea713572d2d31159f824a37c22da82127056c44e4/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b26b0f4428b871a751968285a1ac9648944cea09807177ac639b030bddebcea4", size = 657907, upload-time = "2026-02-20T20:21:05.259Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/fd/d05a4b7acd0154ed758797f0a43b4c0962a843bedfe980115e842c5b2d08/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727", size = 1618857, upload-time = "2026-02-20T20:49:37.309Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/e1/50ee92a5db521de8f35075b5eff060dd43d39ebd46c2181a2042f7070385/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e", size = 1680010, upload-time = "2026-02-20T20:21:13.427Z" },
+    { url = "https://files.pythonhosted.org/packages/29/4b/45d90626aef8e65336bed690106d1382f7a43665e2249017e9527df8823b/greenlet-3.3.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c04c5e06ec3e022cbfe2cd4a846e1d4e50087444f875ff6d2c2ad8445495cf1a", size = 237086, upload-time = "2026-02-20T20:20:45.786Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -557,6 +609,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/2d/43c8522a2038e9d0e7dbdf3a61195ecc31ca576fb1527a528c877e87d973/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:c7e46fcec401dd990405049d2e2f475e2b397779df2519b544b8aab515195282", size = 29498237, upload-time = "2025-01-16T21:34:13.726Z" },
     { url = "https://files.pythonhosted.org/packages/a0/13/59da54728351883c3c1d9fca1710ab8eee82c7beba585df8f25ca925f08f/imageio_ffmpeg-0.6.0-py3-none-win32.whl", hash = "sha256:196faa79366b4a82f95c0f4053191d2013f4714a715780f0ad2a68ff37483cc2", size = 19652251, upload-time = "2025-01-16T21:34:06.812Z" },
     { url = "https://files.pythonhosted.org/packages/2c/c6/fa760e12a2483469e2bf5058c5faff664acf66cadb4df2ad6205b016a73d/imageio_ffmpeg-0.6.0-py3-none-win_amd64.whl", hash = "sha256:02fa47c83703c37df6bfe4896aab339013f62bf02c5ebf2dce6da56af04ffc0a", size = 31246824, upload-time = "2025-01-16T21:34:28.6Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -671,11 +732,18 @@ dependencies = [
     { name = "pillow" },
     { name = "platformdirs" },
     { name = "playsound" },
+    { name = "psycopg", extra = ["binary"] },
     { name = "python-dotenv" },
     { name = "requests" },
+    { name = "sqlalchemy" },
     { name = "srt-equalizer" },
     { name = "termcolor" },
     { name = "undetected-chromedriver" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
 ]
 
 [package.metadata]
@@ -692,12 +760,17 @@ requires-dist = [
     { name = "pillow", specifier = "==9.5.0" },
     { name = "platformdirs", specifier = "==4.1.0" },
     { name = "playsound", specifier = "==1.2.2" },
+    { name = "psycopg", extras = ["binary"], specifier = "==3.2.3" },
     { name = "python-dotenv", specifier = "==1.0.0" },
     { name = "requests", specifier = "==2.31.0" },
+    { name = "sqlalchemy", specifier = "==2.0.36" },
     { name = "srt-equalizer", specifier = "==0.1.8" },
     { name = "termcolor", specifier = "==2.4.0" },
     { name = "undetected-chromedriver" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = "==8.4.1" }]
 
 [[package]]
 name = "moviepy"
@@ -838,6 +911,15 @@ wheels = [
 ]
 
 [[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
 name = "pillow"
 version = "9.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -877,6 +959,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "proglog"
 version = "0.1.12"
 source = { registry = "https://pypi.org/simple" }
@@ -913,6 +1004,64 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/f5/65d838092fd01c44d16037953fd4c2cc851e783de9b8f02b27ec4ffd906f/protobuf-6.33.5-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:8afa18e1d6d20af15b417e728e9f60f3aa108ee76f23c3b2c07a2c3b546d3afd", size = 339411, upload-time = "2026-01-29T21:51:27.446Z" },
     { url = "https://files.pythonhosted.org/packages/9b/53/a9443aa3ca9ba8724fdfa02dd1887c1bcd8e89556b715cfbacca6b63dbec/protobuf-6.33.5-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:cbf16ba3350fb7b889fca858fb215967792dc125b35c7976ca4818bee3521cf0", size = 323465, upload-time = "2026-01-29T21:51:28.925Z" },
     { url = "https://files.pythonhosted.org/packages/57/bf/2086963c69bdac3d7cff1cc7ff79b8ce5ea0bec6797a017e1be338a46248/protobuf-6.33.5-py3-none-any.whl", hash = "sha256:69915a973dd0f60f31a08b8318b73eab2bd6a392c79184b3612226b0a3f8ec02", size = 170687, upload-time = "2026-01-29T21:51:32.557Z" },
+]
+
+[[package]]
+name = "psycopg"
+version = "3.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/ad/7ce016ae63e231575df0498d2395d15f005f05e32d3a2d439038e1bd0851/psycopg-3.2.3.tar.gz", hash = "sha256:a5764f67c27bec8bfac85764d23c534af2c27b893550377e37ce59c12aac47a2", size = 155550, upload-time = "2024-09-29T21:27:25.456Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/21/534b8f5bd9734b7a2fcd3a16b1ee82ef6cad81a4796e95ebf4e0c6a24119/psycopg-3.2.3-py3-none-any.whl", hash = "sha256:644d3973fe26908c73d4be746074f6e5224b03c1101d302d9a53bf565ad64907", size = 197934, upload-time = "2024-09-29T21:21:19.623Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.2.3"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/78/8e8b4063b5cd1cc91cc100fc3e9296b96f52c9a709750b24ade6cfa8021b/psycopg_binary-3.2.3-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:6d8f2144e0d5808c2e2aed40fbebe13869cd00c2ae745aca4b3b16a435edb056", size = 3391535, upload-time = "2024-09-29T21:22:28.111Z" },
+    { url = "https://files.pythonhosted.org/packages/36/7f/04eed0c415d158a0fb1c196957b9c7faec43c7b50d20db05c62e5bd22c93/psycopg_binary-3.2.3-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:94253be2b57ef2fea7ffe08996067aabf56a1eb9648342c9e3bad9e10c46e045", size = 3509175, upload-time = "2024-09-29T21:22:34.989Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/91/042fe504220a6e1a423e6a26d24f198da976b9cce11bc9ab7e9415bac08f/psycopg_binary-3.2.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fda0162b0dbfa5eaed6cdc708179fa27e148cb8490c7d62e5cf30713909658ea", size = 4465647, upload-time = "2024-09-29T21:22:42.729Z" },
+    { url = "https://files.pythonhosted.org/packages/35/7c/4cf02ee263431b306453b7b086ec8e91dcbd5008382d711e82afa829f73e/psycopg_binary-3.2.3-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2c0419cdad8c70eaeb3116bb28e7b42d546f91baf5179d7556f230d40942dc78", size = 4267051, upload-time = "2024-09-29T21:22:48.362Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/9b/cea713d8d75621481ece2dfc7edae6e4f05dfbcaab28fac0dbff9b96fc3a/psycopg_binary-3.2.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:74fbf5dd3ef09beafd3557631e282f00f8af4e7a78fbfce8ab06d9cd5a789aae", size = 4517398, upload-time = "2024-09-29T21:22:56.618Z" },
+    { url = "https://files.pythonhosted.org/packages/56/65/cd4165c45359f4117147b861c16c7b85afbd93cc9efac6116b13f62bc725/psycopg_binary-3.2.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7d784f614e4d53050cbe8abf2ae9d1aaacf8ed31ce57b42ce3bf2a48a66c3a5c", size = 4210644, upload-time = "2024-09-29T21:23:02.941Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/80/14e7bf67613c4344e74fe6ac5c9876a7acb4ddc15e5455c54e24cdc087f8/psycopg_binary-3.2.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4e76ce2475ed4885fe13b8254058be710ec0de74ebd8ef8224cf44a9a3358e5f", size = 3138032, upload-time = "2024-09-29T21:23:06.387Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/81/e18c36de78e0f7a491a754dc74c1bb6b16469d8c240b2add1e856801d567/psycopg_binary-3.2.3-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:5938b257b04c851c2d1e6cb2f8c18318f06017f35be9a5fe761ee1e2e344dfb7", size = 3114329, upload-time = "2024-09-29T21:23:09.483Z" },
+    { url = "https://files.pythonhosted.org/packages/48/39/07b0bf8355cb535ccdd58261a18fb6e786e175492363f5255b446fff6427/psycopg_binary-3.2.3-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:257c4aea6f70a9aef39b2a77d0658a41bf05c243e2bf41895eb02220ac6306f3", size = 3219579, upload-time = "2024-09-29T21:23:14.005Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ea/92c700989b5bdeb8e8e59732191547e32da732692d6c016830c82f9b4ac7/psycopg_binary-3.2.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:06b5cc915e57621eebf2393f4173793ed7e3387295f07fed93ed3fb6a6ccf585", size = 3257145, upload-time = "2024-09-29T21:23:20.458Z" },
+    { url = "https://files.pythonhosted.org/packages/84/49/39f0875fd32a6d77cd22b44887df39eb470039b389c388cee4ba75c0bda7/psycopg_binary-3.2.3-cp311-cp311-win_amd64.whl", hash = "sha256:09baa041856b35598d335b1a74e19a49da8500acedf78164600694c0ba8ce21b", size = 2924948, upload-time = "2024-09-29T21:23:25.591Z" },
+    { url = "https://files.pythonhosted.org/packages/55/6b/9805a5c743c1d54dcd035bd5c069202fde21b4cf69857ca40c2a55e69f8c/psycopg_binary-3.2.3-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:48f8ca6ee8939bab760225b2ab82934d54330eec10afe4394a92d3f2a0c37dd6", size = 3363376, upload-time = "2024-09-29T21:23:30.049Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/82/45ac156b20e08e8f556a323c9568a011c71cf6e734e49667a398719ce0e4/psycopg_binary-3.2.3-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:5361ea13c241d4f0ec3f95e0bf976c15e2e451e9cc7ef2e5ccfc9d170b197a40", size = 3506449, upload-time = "2024-09-29T21:23:34.254Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/be/760cef50e1adfbc87dab2b05b30f544d7297040cce495835df9016556517/psycopg_binary-3.2.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb987f14af7da7c24f803111dbc7392f5070fd350146af3345103f76ea82e339", size = 4445757, upload-time = "2024-09-29T21:23:38.732Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/9c/bae6a9c6949aac577cc93f58705f649b50c62827038903bd75ff8956e63e/psycopg_binary-3.2.3-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0463a11b1cace5a6aeffaf167920707b912b8986a9c7920341c75e3686277920", size = 4248376, upload-time = "2024-09-29T21:23:43.951Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/0e/9db06ef94e4a156f3ed06043ee4f370e21866b0e3b7959691c8c4abfb698/psycopg_binary-3.2.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8b7be9a6c06518967b641fb15032b1ed682fd3b0443f64078899c61034a0bca6", size = 4487765, upload-time = "2024-09-29T21:23:50.999Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/5f/8afc32b60ee8bc5c4af51e7cf6c42d93a989a09609524d0a393106e300cd/psycopg_binary-3.2.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64a607e630d9f4b2797f641884e52b9f8e239d35943f51bef817a384ec1678fe", size = 4188374, upload-time = "2024-09-29T21:24:00.191Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/5d/210cb75aff0296dc5c09bcf67babf8679905412d7a11357b983f0d877360/psycopg_binary-3.2.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:fa33ead69ed133210d96af0c63448b1385df48b9c0247eda735c5896b9e6dbbf", size = 3113180, upload-time = "2024-09-29T21:24:06.433Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ec/46b1a5cdb2fe995b8ec0376f0695003e97fed9ac077e090a3165ea15f735/psycopg_binary-3.2.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:1f8b0d0e99d8e19923e6e07379fa00570be5182c201a8c0b5aaa9a4d4a4ea20b", size = 3099455, upload-time = "2024-09-29T21:24:10.933Z" },
+    { url = "https://files.pythonhosted.org/packages/11/68/eaf85b3421b3f01b638dd6b16f4e9bc8de42eb1d000da62964fb29f8c823/psycopg_binary-3.2.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:709447bd7203b0b2debab1acec23123eb80b386f6c29e7604a5d4326a11e5bd6", size = 3189977, upload-time = "2024-09-29T21:24:15.708Z" },
+    { url = "https://files.pythonhosted.org/packages/83/5a/cf94c3ba87ea6c8331aa0aba36a18a837a3231764457780661968804673e/psycopg_binary-3.2.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5e37d5027e297a627da3551a1e962316d0f88ee4ada74c768f6c9234e26346d9", size = 3232263, upload-time = "2024-09-29T21:24:20.237Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/3a/9d912b16059e87b04e3eb4fca457f079d78d6468f627d5622fbda80e9378/psycopg_binary-3.2.3-cp312-cp312-win_amd64.whl", hash = "sha256:261f0031ee6074765096a19b27ed0f75498a8338c3dcd7f4f0d831e38adf12d1", size = 2912530, upload-time = "2024-09-29T21:24:25.079Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/bf/717c5e51c68e2498b60a6e9f1476cc47953013275a54bf8e23fd5082a72d/psycopg_binary-3.2.3-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:41fdec0182efac66b27478ac15ef54c9ebcecf0e26ed467eb7d6f262a913318b", size = 3360874, upload-time = "2024-09-29T21:24:30.796Z" },
+    { url = "https://files.pythonhosted.org/packages/31/d5/6f9ad6fe5ef80ca9172bc3d028ebae8e9a1ee8aebd917c95c747a5efd85f/psycopg_binary-3.2.3-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:07d019a786eb020c0f984691aa1b994cb79430061065a694cf6f94056c603d26", size = 3502320, upload-time = "2024-09-29T21:24:36.694Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/7b/c58dd26c27fe7a491141ca765c103e702872ff1c174ebd669d73d7fb0b5d/psycopg_binary-3.2.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4c57615791a337378fe5381143259a6c432cdcbb1d3e6428bfb7ce59fff3fb5c", size = 4446950, upload-time = "2024-09-29T21:24:43.028Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/75/acf6a81c788007b7bc0a43b02c22eff7cb19a6ace9e84c32838e86083a3f/psycopg_binary-3.2.3-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e8eb9a4e394926b93ad919cad1b0a918e9b4c846609e8c1cfb6b743683f64da0", size = 4252409, upload-time = "2024-09-29T21:24:47.768Z" },
+    { url = "https://files.pythonhosted.org/packages/83/a5/8a01b923fe42acd185d53f24fb98ead717725ede76a4cd183ff293daf1f1/psycopg_binary-3.2.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5905729668ef1418bd36fbe876322dcb0f90b46811bba96d505af89e6fbdce2f", size = 4488121, upload-time = "2024-09-29T21:24:54.244Z" },
+    { url = "https://files.pythonhosted.org/packages/14/8f/b00e65e204340ab1259ecc8d4cc4c1f72c386be5ca7bfb90ae898a058d68/psycopg_binary-3.2.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd65774ed7d65101b314808b6893e1a75b7664f680c3ef18d2e5c84d570fa393", size = 4190653, upload-time = "2024-09-29T21:25:02.336Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/fc/ba830fc6c9b02b66d1e2fb420736df4d78369760144169a9046f04d72ac6/psycopg_binary-3.2.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:700679c02f9348a0d0a2adcd33a0275717cd0d0aee9d4482b47d935023629505", size = 3118074, upload-time = "2024-09-29T21:25:07.755Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/75/b62d06930a615435e909e05de126aa3d49f6ec2993d1aa6a99e7faab5570/psycopg_binary-3.2.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:96334bb64d054e36fed346c50c4190bad9d7c586376204f50bede21a913bf942", size = 3100457, upload-time = "2024-09-29T21:25:13.002Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e5/32dc7518325d0010813853a87b19c784d8b11fdb17f5c0e0c148c5ac77af/psycopg_binary-3.2.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:9099e443d4cc24ac6872e6a05f93205ba1a231b1a8917317b07c9ef2b955f1f4", size = 3192788, upload-time = "2024-09-29T21:25:18.815Z" },
+    { url = "https://files.pythonhosted.org/packages/23/a3/d1aa04329253c024a2323051774446770d47b43073874a3de8cca797ed8e/psycopg_binary-3.2.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1985ab05e9abebfbdf3163a16ebb37fbc5d49aff2bf5b3d7375ff0920bbb54cd", size = 3234247, upload-time = "2024-09-29T21:25:24.005Z" },
+    { url = "https://files.pythonhosted.org/packages/03/20/b675af723b9a61d48abd6a3d64cbb9797697d330255d1f8105713d54ed8e/psycopg_binary-3.2.3-cp313-cp313-win_amd64.whl", hash = "sha256:e90352d7b610b4693fad0feea48549d4315d10f1eba5605421c92bb834e90170", size = 2913413, upload-time = "2024-09-29T21:25:28.151Z" },
 ]
 
 [[package]]
@@ -1072,6 +1221,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
 name = "pyparsing"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1087,6 +1245,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bd/11/293dd436aea955d45fc4e8a35b6ae7270f5b8e00b53cf6c024c83b657a11/PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0", size = 284429, upload-time = "2019-09-20T02:07:35.714Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8d/59/b4572118e098ac8e46e399a1dd0f2d85403ce8bbaad9ec79373ed6badaf9/PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5", size = 16725, upload-time = "2019-09-20T02:06:22.938Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/ba/45911d754e8eba3d5a841a5ce61a65a685ff1798421ac054f85aa8747dfb/pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c", size = 1517714, upload-time = "2025-06-18T05:48:06.109Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7", size = 365474, upload-time = "2025-06-18T05:48:03.955Z" },
 ]
 
 [[package]]
@@ -1167,6 +1341,43 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
+name = "sqlalchemy"
+version = "2.0.36"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "(python_full_version < '3.13' and platform_machine == 'AMD64') or (python_full_version < '3.13' and platform_machine == 'WIN32') or (python_full_version < '3.13' and platform_machine == 'aarch64') or (python_full_version < '3.13' and platform_machine == 'amd64') or (python_full_version < '3.13' and platform_machine == 'ppc64le') or (python_full_version < '3.13' and platform_machine == 'win32') or (python_full_version < '3.13' and platform_machine == 'x86_64')" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/65/9cbc9c4c3287bed2499e05033e207473504dc4df999ce49385fb1f8b058a/sqlalchemy-2.0.36.tar.gz", hash = "sha256:7f2767680b6d2398aea7082e45a774b2b0767b5c8d8ffb9c8b683088ea9b29c5", size = 9574485, upload-time = "2024-10-15T19:41:44.446Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/4e/5a67963fd7cbc1beb8bd2152e907419f4c940ef04600b10151a751fe9e06/SQLAlchemy-2.0.36-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:fd3a55deef00f689ce931d4d1b23fa9f04c880a48ee97af488fd215cf24e2a6c", size = 2093782, upload-time = "2024-10-16T00:41:28.675Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/24/30e33b6389ebb5a17df2a4243b091bc709fb3dfc9a48c8d72f8e037c943d/SQLAlchemy-2.0.36-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4f5e9cd989b45b73bd359f693b935364f7e1f79486e29015813c338450aa5a71", size = 2084180, upload-time = "2024-10-16T00:41:30.374Z" },
+    { url = "https://files.pythonhosted.org/packages/10/1e/70e9ed2143a27065246be40f78637ad5160ea0f5fd32f8cab819a31ff54d/SQLAlchemy-2.0.36-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d0ddd9db6e59c44875211bc4c7953a9f6638b937b0a88ae6d09eb46cced54eff", size = 3202469, upload-time = "2024-10-15T21:41:05.807Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/5f/95e0ed74093ac3c0db6acfa944d4d8ac6284ef5e1136b878a327ea1f975a/SQLAlchemy-2.0.36-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2519f3a5d0517fc159afab1015e54bb81b4406c278749779be57a569d8d1bb0d", size = 3202464, upload-time = "2024-10-15T20:03:40.532Z" },
+    { url = "https://files.pythonhosted.org/packages/91/95/2cf9b85a6bc2ee660e40594dffe04e777e7b8617fd0c6d77a0f782ea96c9/SQLAlchemy-2.0.36-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:59b1ee96617135f6e1d6f275bbe988f419c5178016f3d41d3c0abb0c819f75bb", size = 3139508, upload-time = "2024-10-15T21:41:07.508Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ea/f0c01bc646456e4345c0fb5a3ddef457326285c2dc60435b0eb96b61bf31/SQLAlchemy-2.0.36-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:39769a115f730d683b0eb7b694db9789267bcd027326cccc3125e862eb03bfd8", size = 3159837, upload-time = "2024-10-15T20:03:42.578Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/93/c8edbf153ee38fe529773240877bf1332ed95328aceef6254288f446994e/SQLAlchemy-2.0.36-cp311-cp311-win32.whl", hash = "sha256:66bffbad8d6271bb1cc2f9a4ea4f86f80fe5e2e3e501a5ae2a3dc6a76e604e6f", size = 2064529, upload-time = "2024-10-15T20:07:21.129Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/03/d12b7c1d36fd80150c1d52e121614cf9377dac99e5497af8d8f5b2a8db64/SQLAlchemy-2.0.36-cp311-cp311-win_amd64.whl", hash = "sha256:23623166bfefe1487d81b698c423f8678e80df8b54614c2bf4b4cfcd7c711959", size = 2089874, upload-time = "2024-10-15T20:07:22.477Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/bf/005dc47f0e57556e14512d5542f3f183b94fde46e15ff1588ec58ca89555/SQLAlchemy-2.0.36-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f7b64e6ec3f02c35647be6b4851008b26cff592a95ecb13b6788a54ef80bbdd4", size = 2092378, upload-time = "2024-10-16T00:43:55.469Z" },
+    { url = "https://files.pythonhosted.org/packages/94/65/f109d5720779a08e6e324ec89a744f5f92c48bd8005edc814bf72fbb24e5/SQLAlchemy-2.0.36-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:46331b00096a6db1fdc052d55b101dbbfc99155a548e20a0e4a8e5e4d1362855", size = 2082778, upload-time = "2024-10-16T00:43:57.304Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f6/d9aa8c49c44f9b8c9b9dada1f12fa78df3d4c42aa2de437164b83ee1123c/SQLAlchemy-2.0.36-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fdf3386a801ea5aba17c6410dd1dc8d39cf454ca2565541b5ac42a84e1e28f53", size = 3232191, upload-time = "2024-10-15T21:31:12.896Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/ab/81d4514527c068670cb1d7ab62a81a185df53a7c379bd2a5636e83d09ede/SQLAlchemy-2.0.36-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac9dfa18ff2a67b09b372d5db8743c27966abf0e5344c555d86cc7199f7ad83a", size = 3243044, upload-time = "2024-10-15T20:16:28.954Z" },
+    { url = "https://files.pythonhosted.org/packages/35/b4/f87c014ecf5167dc669199cafdb20a7358ff4b1d49ce3622cc48571f811c/SQLAlchemy-2.0.36-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:90812a8933df713fdf748b355527e3af257a11e415b613dd794512461eb8a686", size = 3178511, upload-time = "2024-10-15T21:31:16.792Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/09/badfc9293bc3ccba6ede05e5f2b44a760aa47d84da1fc5a326e963e3d4d9/SQLAlchemy-2.0.36-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1bc330d9d29c7f06f003ab10e1eaced295e87940405afe1b110f2eb93a233588", size = 3205147, upload-time = "2024-10-15T20:16:32.718Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/60/70e681de02a13c4b27979b7b78da3058c49bacc9858c89ba672e030f03f2/SQLAlchemy-2.0.36-cp312-cp312-win32.whl", hash = "sha256:79d2e78abc26d871875b419e1fd3c0bca31a1cb0043277d0d850014599626c2e", size = 2062709, upload-time = "2024-10-15T20:16:29.946Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/ed/f6cd9395e41bfe47dd253d74d2dfc3cab34980d4e20c8878cb1117306085/SQLAlchemy-2.0.36-cp312-cp312-win_amd64.whl", hash = "sha256:b544ad1935a8541d177cb402948b94e871067656b3a0b9e91dbec136b06a2ff5", size = 2088433, upload-time = "2024-10-15T20:16:33.501Z" },
+    { url = "https://files.pythonhosted.org/packages/78/5c/236398ae3678b3237726819b484f15f5c038a9549da01703a771f05a00d6/SQLAlchemy-2.0.36-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b5cc79df7f4bc3d11e4b542596c03826063092611e481fcf1c9dfee3c94355ef", size = 2087651, upload-time = "2024-10-16T00:43:59.168Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/14/55c47420c0d23fb67a35af8be4719199b81c59f3084c28d131a7767b0b0b/SQLAlchemy-2.0.36-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3c01117dd36800f2ecaa238c65365b7b16497adc1522bf84906e5710ee9ba0e8", size = 2078132, upload-time = "2024-10-16T00:44:01.279Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/97/1e843b36abff8c4a7aa2e37f9bea364f90d021754c2de94d792c2d91405b/SQLAlchemy-2.0.36-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9bc633f4ee4b4c46e7adcb3a9b5ec083bf1d9a97c1d3854b92749d935de40b9b", size = 3164559, upload-time = "2024-10-15T21:31:18.961Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/c5/07f18a897b997f6d6b234fab2bf31dccf66d5d16a79fe329aefc95cd7461/SQLAlchemy-2.0.36-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9e46ed38affdfc95d2c958de328d037d87801cfcbea6d421000859e9789e61c2", size = 3177897, upload-time = "2024-10-15T20:16:35.048Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/cd/e16f3cbefd82b5c40b33732da634ec67a5f33b587744c7ab41699789d492/SQLAlchemy-2.0.36-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:b2985c0b06e989c043f1dc09d4fe89e1616aadd35392aea2844f0458a989eacf", size = 3111289, upload-time = "2024-10-15T21:31:21.11Z" },
+    { url = "https://files.pythonhosted.org/packages/15/85/5b8a3b0bc29c9928aa62b5c91fcc8335f57c1de0a6343873b5f372e3672b/SQLAlchemy-2.0.36-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4a121d62ebe7d26fec9155f83f8be5189ef1405f5973ea4874a26fab9f1e262c", size = 3139491, upload-time = "2024-10-15T20:16:38.048Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/95/81babb6089938680dfe2cd3f88cd3fd39cccd1543b7cb603b21ad881bff1/SQLAlchemy-2.0.36-cp313-cp313-win32.whl", hash = "sha256:0572f4bd6f94752167adfd7c1bed84f4b240ee6203a95e05d1e208d488d0d436", size = 2060439, upload-time = "2024-10-15T20:16:36.182Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ce/5f7428df55660d6879d0522adc73a3364970b5ef33ec17fa125c5dbcac1d/SQLAlchemy-2.0.36-cp313-cp313-win_amd64.whl", hash = "sha256:8c78ac40bde930c60e0f78b3cd184c580f89456dd87fc08f9e3ee3ce8765ce88", size = 2084574, upload-time = "2024-10-15T20:16:38.686Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/49/21633706dd6feb14cd3f7935fc00b60870ea057686035e1a99ae6d9d9d53/SQLAlchemy-2.0.36-py3-none-any.whl", hash = "sha256:fddbe92b4760c6f5d48162aef14824add991aeda8ddadb3c31d56eb15ca69f8e", size = 1883787, upload-time = "2024-10-15T20:04:30.265Z" },
 ]
 
 [[package]]
@@ -1258,6 +1469,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2025.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- replaces in-request generation + SSE stream with a database-backed job queue and a dedicated worker process
- adds queue/job/event persistence via SQLAlchemy models and repository helpers, including cancellation and lifecycle tracking endpoints
- updates frontend generation flow to poll per-job status/events and adds Docker/database/dependency wiring for queue execution

## Why
- makes generation restart-safe and durable by persisting state in the database
- decouples API responsiveness from long-running video rendering work